### PR TITLE
Activate the doctests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,7 +70,7 @@ jobs:
             Pkg.instantiate()'
             - name: "Run doctests"
             run: |
-            julia --project=docs --color=yes test/doctest.jl
+                julia --project=docs --color=yes test/doctest.jl
       - name: "Deploy documentation"
         run: julia --project=docs --color=yes docs/make.jl
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,9 +68,9 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
-            - name: "Run doctests"
-              run: |
-                julia --project=docs --color=yes test/doctest.jl
+      - name: "Run doctests"
+        run: |
+          julia --project=docs --color=yes test/doctest.jl
       - name: "Deploy documentation"
         run: julia --project=docs --color=yes docs/make.jl
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,9 +68,9 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
-            #- name: "Run doctests"
-            #run: |
-            #julia --project=docs --color=yes test/doctest.jl
+            - name: "Run doctests"
+            run: |
+            julia --project=docs --color=yes test/doctest.jl
       - name: "Deploy documentation"
         run: julia --project=docs --color=yes docs/make.jl
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,7 +69,7 @@ jobs:
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
             - name: "Run doctests"
-            run: |
+              run: |
                 julia --project=docs --color=yes test/doctest.jl
       - name: "Deploy documentation"
         run: julia --project=docs --color=yes docs/make.jl

--- a/test/doctest.jl
+++ b/test/doctest.jl
@@ -1,0 +1,5 @@
+using Documenter, JToric
+
+DocMeta.setdocmeta!(JToric, :DocTestSetup, :(using JToric, Random); recursive = true)
+
+doctest(JToric)


### PR DESCRIPTION
This PR aims to close:
- https://github.com/oscar-system/JToric.jl/issues/46
- https://github.com/oscar-system/JToric.jl/issues/12

It is unclear to me why the commit in this PR triggers the documentation to fail. Also, it is unclear to me why the documentation is not deployed after https://github.com/oscar-system/JToric.jl/pull/38.

@fingolfin Any ideas/suggestions?