### PR TITLE
Refactoring for Oscar compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 CapAndHomalg = "1.1.8"
 GAP = "0.6.2"
 Oscar = "0.6"
-Polymake = "0.5"
+Polymake = "0.5.8"
 julia = "1.4"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ GAP = "c863536a-3901-11e9-33e7-d5cd0df7b904"
 Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Polymake = "d720cf60-89b5-51f5-aff5-213f193123e7"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [compat]
 CapAndHomalg = "1.1.8"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"
 JToric = "9bfa4af0-0a41-40a3-86ae-7e8f6cc9e7ab"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,5 @@
 push!(LOAD_PATH,"../src/")
-using Documenter, JToric
+using Documenter, JToric, DocumenterMarkdown
 
 # ensure JToric is loaded for the doc tests
 DocMeta.setdocmeta!(JToric, :DocTestSetup, :(using JToric, Random); recursive = true)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,7 +23,8 @@ version
 ### Constructors
 
 ```@docs
-NormalToricVariety
+NormalToricVariety(PF::PolyhedralFan)
+NormalToricVariety( r::Matrix{Int}, c::Vector{Vector{Int}} )
 projective_space
 hirzebruch_surface
 del_pezzo
@@ -39,14 +40,14 @@ ntv_polymake2gap
 ### Properties of toric varieties
 
 ```@docs
-is_normal_variety
-is_affine
-is_projective
-is_smooth
-is_complete
+isnormal
+isaffine
+isprojective
+issmooth
+iscomplete
 has_torusfactor
 is_orbifold
-is_simplicial
+issimplicial
 is_isomorphic_to_projective_space
 is_direct_product_of_projective_spaces
 is_gorenstein

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -92,6 +92,7 @@ zariski_cotangent_sheaf_via_euler_sequence
 zariski_cotangent_sheaf_via_poincare_residue_map
 nef_cone
 mori_cone
+toric_ideal_binomial_generators(antv::AffineNormalToricVariety)
 ```
 
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -123,11 +123,15 @@ divisor_of_class
 ### Properties of toric divisors
 
 ```@docs
-is_cartier
-is_principal
-is_primedivisor
-is_basepoint_free
-is_ample
-is_very_ample
-is_nef
+isample
+isbasepoint_free
+iscartier
+iseffective(td::ToricDivisor)
+isintegral(td::ToricDivisor) 
+isnef
+isprimedivisor
+isprincipal
+isq_cartier
+isvery_ample
+polyhedron_of_divisor(td::ToricDivisor)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -115,7 +115,7 @@ nr_of_q_rational_points( v::NormalToricVariety, i::Int )
 ### Constructors
 
 ```@docs
-create_divisor
+ToricDivisor
 divisor_of_character
 divisor_of_class
 ```
@@ -129,7 +129,7 @@ iscartier
 iseffective(td::ToricDivisor)
 isintegral(td::ToricDivisor) 
 isnef
-isprimedivisor
+is_primedivisor
 isprincipal
 isq_cartier
 isvery_ample

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,6 +23,8 @@ version
 ### Constructors
 
 ```@docs
+AffineNormalToricVariety(C::Cone)
+NormalToricVariety(C::Cone)
 NormalToricVariety(PF::PolyhedralFan)
 NormalToricVariety( r::Matrix{Int}, c::Vector{Vector{Int}} )
 projective_space

--- a/src/AttributesAndMethods.jl
+++ b/src/AttributesAndMethods.jl
@@ -2,7 +2,7 @@
 # 1: Attributes of ToricVarieties
 ######################
 
-"""
+@doc Markdown.doc"""
     affine_open_covering( v::AbstractNormalToricVariety )
 
 Computes an affine open cover of the normal toric variety `v`, i.e. returns a list of affine toric varieties.
@@ -20,7 +20,7 @@ end
 export CoxRing
 
 
-"""
+@doc Markdown.doc"""
     cox_ring( v::AbstractNormalToricVariety )
 
 Computes the Cox ring of the normal toric variety `v`.
@@ -32,7 +32,7 @@ end
 export cox_ring
 
 
-"""
+@doc Markdown.doc"""
     list_of_variables_of_cox_ring( v::AbstractNormalToricVariety )
 
 Computes the list of homogeneous variables of the Cox ring of the normal toric variety `v`.
@@ -50,7 +50,7 @@ end
 export ClassGroup
 
 
-"""
+@doc Markdown.doc"""
     class_group( v::AbstractNormalToricVariety )
 
 Computes the class group of the normal toric variety `v`.
@@ -68,7 +68,7 @@ end
 export TorusInvariantDivisorGroup
 
 
-"""
+@doc Markdown.doc"""
     torus_invariant_divisor_group( v::AbstractNormalToricVariety )
 
 Computes the torus invariant divisor class group of the normal toric variety `v`.
@@ -86,7 +86,7 @@ end
 export MapFromCharacterToPrincipalDivisor
 
 
-"""
+@doc Markdown.doc"""
     map_from_character_to_principal_divisor( v::AbstractNormalToricVariety )
 
 Computes the map from the character lattice to the principal divisors of the normal toric variety `v`.
@@ -104,7 +104,7 @@ end
 export MapFromWeilDivisorsToClassGroup
 
 
-"""
+@doc Markdown.doc"""
     map_from_weil_divisors_to_class_group( v::AbstractNormalToricVariety )
 
 Computes the map from the Weil divisors to the Class group of the normal toric variety `v`.
@@ -116,7 +116,7 @@ end
 export map_from_weil_divisors_to_class_group
 
 
-"""
+@doc Markdown.doc"""
     dim( v::AbstractNormalToricVariety )
 
 Computes the dimension of the normal toric variety `v`.
@@ -127,7 +127,7 @@ end
 export dim
 
 
-"""
+@doc Markdown.doc"""
     dim_of_torusfactor( v::AbstractNormalToricVariety )
 
 Computes the dimension of the torus factor of the normal toric variety `v`.
@@ -144,7 +144,7 @@ end
 export CoordinateRingOfTorus
 
 
-"""
+@doc Markdown.doc"""
     coordinate_ring_of_torus( v::AbstractNormalToricVariety )
 
 Computes the coordinate ring of the torus of the normal toric variety `v`.
@@ -156,7 +156,7 @@ end
 export coordinate_ring_of_torus
 
 
-"""
+@doc Markdown.doc"""
     list_of_variables_of_coordinate_ring_of_torus( v::AbstractNormalToricVariety )
 
 Computes the list of homogeneous coordinates of the coordinate ring of the torus of the normal toric variety `v`.
@@ -168,7 +168,7 @@ end
 export list_of_variables_of_coordinate_ring_of_torus
 
 
-"""
+@doc Markdown.doc"""
     is_product_of( v::AbstractNormalToricVariety )
 
 Identifies the factors from which the normal toric variety `v` has been constructed in GAP.
@@ -180,7 +180,7 @@ end
 export is_product_of
 
 
-"""
+@doc Markdown.doc"""
     factors( v::AbstractNormalToricVariety )
 
 Identifies the factors from which the normal toric variety `v` has been constructed in GAP.
@@ -198,7 +198,7 @@ end
 export CharacterLattice
 
 
-"""
+@doc Markdown.doc"""
     character_lattice( v::AbstractNormalToricVariety )
 
 Computes the character lattice of the normal toric variety `v`.
@@ -210,7 +210,7 @@ end
 export character_lattice
 
 
-"""
+@doc Markdown.doc"""
     torus_invariant_prime_divisors( v::AbstractNormalToricVariety )
 
 Computes the torus invariant prime divisors of the normal toric variety `v`.
@@ -228,7 +228,7 @@ end
 export IrrelevantIdeal
 
 
-"""
+@doc Markdown.doc"""
     irrelevant_ideal( v::AbstractNormalToricVariety )
 
 Computes the irrelevant ideal of the normal toric variety `v`.
@@ -246,7 +246,7 @@ end
 export StanleyReisnerIdeal
 
 
-"""
+@doc Markdown.doc"""
     stanley_reisner_ideal( v::AbstractNormalToricVariety )
 
 Computes the Stanley-Reisner ideal of the normal toric variety `v`.
@@ -264,7 +264,7 @@ end
 export MorphismFromCoxVariety
 
 
-"""
+@doc Markdown.doc"""
     morphism_from_cox_variety( v::AbstractNormalToricVariety )
 
 Computes the morphism from the Cox variety of the normal toric variety `v`.
@@ -276,7 +276,7 @@ end
 export morphism_from_cox_variety
 
 
-"""
+@doc Markdown.doc"""
     cox_variety( v::AbstractNormalToricVariety )
 
 Computes the Cox variety of the normal toric variety `v`.
@@ -296,7 +296,7 @@ end
 export Fan
 
 
-"""
+@doc Markdown.doc"""
     fan_of_variety( v::AbstractNormalToricVariety )
 
 Computes the fan of the normal toric variety `v`.
@@ -314,7 +314,7 @@ end
 export fan_of_variety
 
 
-"""
+@doc Markdown.doc"""
     fan( v::AbstractNormalToricVariety )
 
 A convenience method for `fan_of_variety( v::AbstractNormalToricVariety )`.
@@ -331,7 +331,7 @@ end
 export CartierTorusInvariantDivisorGroup
 
 
-"""
+@doc Markdown.doc"""
     cartier_torus_invariant_divisor_group( v::AbstractNormalToricVariety )
 
 Computes the group of Cartier and torus invariant divisors of the normal toric variety `v`.
@@ -349,7 +349,7 @@ end
 export PicardGroup
 
 
-"""
+@doc Markdown.doc"""
     picard_group( v::AbstractNormalToricVariety )
 
 Computes the Picard group of the normal toric variety `v`.
@@ -361,7 +361,7 @@ end
 export picard_group
 
 
-"""
+@doc Markdown.doc"""
     name_of_variety( v::AbstractNormalToricVariety )
 
 Returns the name of the normal toric variety `v`, if set. Otherwise returns "No name set for this variety".
@@ -382,7 +382,7 @@ end
 export ZariskiCotangentSheaf
 
 
-"""
+@doc Markdown.doc"""
     zariski_cotangent_sheaf( v::AbstractNormalToricVariety )
 
 Returns the Zariski cotangent sheaf of the normal toric variety `v`.
@@ -400,7 +400,7 @@ end
 export CotangentSheaf
 
 
-"""
+@doc Markdown.doc"""
     cotangent_sheaf( v::AbstractNormalToricVariety )
 
 Returns the cotangent sheaf of the normal toric variety `v`.
@@ -412,7 +412,7 @@ end
 export cotangent_sheaf
 
 
-"""
+@doc Markdown.doc"""
     euler_characteristic( v::AbstractNormalToricVariety )
 
 Computes the Euler characteristic of the normal toric variety `v`.
@@ -423,7 +423,7 @@ end
 export euler_characteristic
 
 
-"""
+@doc Markdown.doc"""
     weil_divisors_of_variety( v::AbstractNormalToricVariety )
 
 Compute the Weil divisors of the normal toric variety `v`.
@@ -441,7 +441,7 @@ end
 export ZariskiCotangentSheafViaEulerSequence
 
 
-"""
+@doc Markdown.doc"""
     zariski_cotangent_sheaf_via_euler_sequence( v::AbstractNormalToricVariety )
 
 Computes the Zariski cotangent sheaf of the normal toric variety `v` via the Euler sequence.
@@ -459,7 +459,7 @@ end
 export ZariskiCotangentSheafViaPoincareResidueMap
 
 
-"""
+@doc Markdown.doc"""
     zariski_cotangent_sheaf_via_poincare_residue_map( v::AbstractNormalToricVariety )
 
 Computes the Zariski cotangent sheaf of the normal toric variety `v` via the Poincare residue map.
@@ -519,7 +519,7 @@ export mori_cone
 # 2: Methods of ToricVarieties
 ######################
 
-"""
+@doc Markdown.doc"""
     set_name_of_variety( v::AbstractNormalToricVariety, name::String )
 
 Sets the name of the normal toric variety `v` to `name`.
@@ -531,7 +531,7 @@ end
 export set_name_of_variety
 
 
-"""
+@doc Markdown.doc"""
     coordinate_ring_of_torus( v::AbstractNormalToricVariety, names::Vector{String} )
 
 Compute the coordinate ring of the torus factor of the normal toric variety `v`, using `names` as label for the homogeneous coordinates.
@@ -545,7 +545,7 @@ end
 export coordinate_ring_of_torus
 
 
-"""
+@doc Markdown.doc"""
     cox_ring( v::AbstractNormalToricVariety, name::String )
 
 Compute the Cox ring of the normal toric variety `v`, using `name` as label for the homogeneous coordinates.
@@ -558,7 +558,7 @@ end
 export cox_ring
 
 
-"""
+@doc Markdown.doc"""
     Base.:*( v::AbstractNormalToricVariety, w::AbstractNormalToricVariety )
 
 Compute the direct product of the normal toric varieties `v` and `w`.
@@ -582,7 +582,7 @@ end
 export CharacterToRationalFunction
 
 
-"""
+@doc Markdown.doc"""
     character_to_rational_function( l::Vector{Int}, v::AbstractNormalToricVariety )
 
 Turn the character `l` of the normal toric variety `v` into a rational function.
@@ -594,7 +594,7 @@ end
 export character_to_rational_function
 
 
-"""
+@doc Markdown.doc"""
     blowup_on_ith_minimal_torus_orbit( v::AbstractNormalToricVariety, i::Int )
 
 Compute the blow up of the normal toric variety `v` on the i-th minimal torus orbit.
@@ -606,7 +606,7 @@ end
 export blowup_on_ith_minimal_torus_orbit
 
 
-"""
+@doc Markdown.doc"""
     ith_betti_number( v::AbstractNormalToricVariety, i::Int )
 
 Compute the i-th Betti number of the normal toric variety `v`.
@@ -617,7 +617,7 @@ end
 export ith_betti_number
 
 
-"""
+@doc Markdown.doc"""
     nr_of_q_rational_points( v::AbstractNormalToricVariety, i::Int )
 
 Compute the number of q-rational points of the normal toric variety `v`.

--- a/src/AttributesAndMethods.jl
+++ b/src/AttributesAndMethods.jl
@@ -3,13 +3,13 @@
 ######################
 
 """
-    affine_open_covering( v::NormalToricVariety )
+    affine_open_covering( v::AbstractNormalToricVariety )
 
 Computes an affine open cover of the normal toric variety `v`, i.e. returns a list of affine toric varieties.
 """
-function affine_open_covering( v::NormalToricVariety )
+function affine_open_covering( v::AbstractNormalToricVariety )
     gap_cover = GAP.Globals.AffineOpenCovering( v.GapNTV )
-    return [ NormalToricVariety( v ) for v in gap_cover ]
+    return [ AbstractNormalToricVariety( v ) for v in gap_cover ]
 end
 export affine_open_covering
 
@@ -21,11 +21,11 @@ export CoxRing
 
 
 """
-    cox_ring( v::NormalToricVariety )
+    cox_ring( v::AbstractNormalToricVariety )
 
 Computes the Cox ring of the normal toric variety `v`.
 """
-function cox_ring( v::NormalToricVariety )
+function cox_ring( v::AbstractNormalToricVariety )
     gap_ring = GAP.Globals.CoxRing( v.GapNTV )
     return CoxRing( gap_ring )
 end
@@ -33,11 +33,11 @@ export cox_ring
 
 
 """
-    list_of_variables_of_cox_ring( v::NormalToricVariety )
+    list_of_variables_of_cox_ring( v::AbstractNormalToricVariety )
 
 Computes the list of homogeneous variables of the Cox ring of the normal toric variety `v`.
 """
-function list_of_variables_of_cox_ring(v::NormalToricVariety)
+function list_of_variables_of_cox_ring(v::AbstractNormalToricVariety)
     vars = GAP.Globals.ListOfVariablesOfCoxRing(v.GapNTV)
     return Vector{String}(vars)
 end
@@ -51,11 +51,11 @@ export ClassGroup
 
 
 """
-    class_group( v::NormalToricVariety )
+    class_group( v::AbstractNormalToricVariety )
 
 Computes the class group of the normal toric variety `v`.
 """
-function class_group( v::NormalToricVariety )
+function class_group( v::AbstractNormalToricVariety )
     gap_class_group = GAP.Globals.ClassGroup( v.GapNTV )
     return ClassGroup( gap_class_group )
 end
@@ -69,11 +69,11 @@ export TorusInvariantDivisorGroup
 
 
 """
-    torus_invariant_divisor_group( v::NormalToricVariety )
+    torus_invariant_divisor_group( v::AbstractNormalToricVariety )
 
 Computes the torus invariant divisor class group of the normal toric variety `v`.
 """
-function torus_invariant_divisor_group( v::NormalToricVariety )
+function torus_invariant_divisor_group( v::AbstractNormalToricVariety )
     gap_TorusInvariantDivisorGroup = GAP.Globals.TorusInvariantDivisorGroup( v.GapNTV )
     return TorusInvariantDivisorGroup( gap_TorusInvariantDivisorGroup )
 end
@@ -87,11 +87,11 @@ export MapFromCharacterToPrincipalDivisor
 
 
 """
-    map_from_character_to_principal_divisor( v::NormalToricVariety )
+    map_from_character_to_principal_divisor( v::AbstractNormalToricVariety )
 
 Computes the map from the character lattice to the principal divisors of the normal toric variety `v`.
 """
-function map_from_character_to_principal_divisor( v::NormalToricVariety )
+function map_from_character_to_principal_divisor( v::AbstractNormalToricVariety )
     gap_MapFromCharacterToPrincipalDivisor = GAP.Globals.MapFromCharacterToPrincipalDivisor( v.GapNTV )
     return MapFromCharacterToPrincipalDivisor( gap_MapFromCharacterToPrincipalDivisor )
 end
@@ -105,11 +105,11 @@ export MapFromWeilDivisorsToClassGroup
 
 
 """
-    map_from_weil_divisors_to_class_group( v::NormalToricVariety )
+    map_from_weil_divisors_to_class_group( v::AbstractNormalToricVariety )
 
 Computes the map from the Weil divisors to the Class group of the normal toric variety `v`.
 """
-function map_from_weil_divisors_to_class_group( v::NormalToricVariety )
+function map_from_weil_divisors_to_class_group( v::AbstractNormalToricVariety )
     gap_MapFromWeilDivisorsToClassGroup = GAP.Globals.MapFromWeilDivisorsToClassGroup( v.GapNTV )
     return MapFromWeilDivisorsToClassGroup( gap_MapFromWeilDivisorsToClassGroup )
 end
@@ -117,22 +117,22 @@ export map_from_weil_divisors_to_class_group
 
 
 """
-    dim( v::NormalToricVariety )
+    dim( v::AbstractNormalToricVariety )
 
 Computes the dimension of the normal toric variety `v`.
 """
-function dim( v::NormalToricVariety )
+function dim( v::AbstractNormalToricVariety )
     return GAP.Globals.Dimension(v.GapNTV)::Int
 end
 export dim
 
 
 """
-    dim_of_torusfactor( v::NormalToricVariety )
+    dim_of_torusfactor( v::AbstractNormalToricVariety )
 
 Computes the dimension of the torus factor of the normal toric variety `v`.
 """
-function dim_of_torusfactor( v::NormalToricVariety )
+function dim_of_torusfactor( v::AbstractNormalToricVariety )
     return GAP.Globals.DimensionOfTorusfactor( v.GapNTV )::Int
 end
 export dim_of_torusfactor
@@ -145,11 +145,11 @@ export CoordinateRingOfTorus
 
 
 """
-    coordinate_ring_of_torus( v::NormalToricVariety )
+    coordinate_ring_of_torus( v::AbstractNormalToricVariety )
 
 Computes the coordinate ring of the torus of the normal toric variety `v`.
 """
-function coordinate_ring_of_torus( v::NormalToricVariety )
+function coordinate_ring_of_torus( v::AbstractNormalToricVariety )
     gap_CoordinateRingOfTorus = GAP.Globals.CoordinateRingOfTorus( v.GapNTV )
     return CoordinateRingOfTorus( gap_CoordinateRingOfTorus )
 end
@@ -157,11 +157,11 @@ export coordinate_ring_of_torus
 
 
 """
-    list_of_variables_of_coordinate_ring_of_torus( v::NormalToricVariety )
+    list_of_variables_of_coordinate_ring_of_torus( v::AbstractNormalToricVariety )
 
 Computes the list of homogeneous coordinates of the coordinate ring of the torus of the normal toric variety `v`.
 """
-function list_of_variables_of_coordinate_ring_of_torus(v::NormalToricVariety)
+function list_of_variables_of_coordinate_ring_of_torus(v::AbstractNormalToricVariety)
     vars = GAP.Globals.ListOfVariablesOfCoordinateRingOfTorus(v.GapNTV)
     return Vector{String}(vars)
 end
@@ -169,11 +169,11 @@ export list_of_variables_of_coordinate_ring_of_torus
 
 
 """
-    is_product_of( v::NormalToricVariety )
+    is_product_of( v::AbstractNormalToricVariety )
 
 Identifies the factors from which the normal toric variety `v` has been constructed in GAP.
 """
-function is_product_of(v::NormalToricVariety)
+function is_product_of(v::AbstractNormalToricVariety)
     factors = GAP.Globals.IsProductOf(v.GapNTV)
     return [ NormalToricVariety( f ) for f in factors ]
 end
@@ -181,11 +181,11 @@ export is_product_of
 
 
 """
-    factors( v::NormalToricVariety )
+    factors( v::AbstractNormalToricVariety )
 
 Identifies the factors from which the normal toric variety `v` has been constructed in GAP.
 """
-function factors( v::NormalToricVariety )
+function factors( v::AbstractNormalToricVariety )
     gap_factors = GAP.Globals.Factors( v.GapNTV )
     return [ NormalToricVariety( f ) for f in gap_factors ]
 end
@@ -199,11 +199,11 @@ export CharacterLattice
 
 
 """
-    character_lattice( v::NormalToricVariety )
+    character_lattice( v::AbstractNormalToricVariety )
 
 Computes the character lattice of the normal toric variety `v`.
 """
-function character_lattice( v::NormalToricVariety )
+function character_lattice( v::AbstractNormalToricVariety )
     gap_CharacterLattice = GAP.Globals.CharacterLattice( v.GapNTV )
     return CharacterLattice( gap_CharacterLattice )
 end
@@ -211,11 +211,11 @@ export character_lattice
 
 
 """
-    torus_invariant_prime_divisors( v::NormalToricVariety )
+    torus_invariant_prime_divisors( v::AbstractNormalToricVariety )
 
 Computes the torus invariant prime divisors of the normal toric variety `v`.
 """
-function torus_invariant_prime_divisors( v::NormalToricVariety )
+function torus_invariant_prime_divisors( v::AbstractNormalToricVariety )
     divisors = GAP.Globals.TorusInvariantPrimeDivisors( v.GapNTV )
     return [ ToricDivisor( d ) for d in divisors ]    
 end
@@ -229,11 +229,11 @@ export IrrelevantIdeal
 
 
 """
-    irrelevant_ideal( v::NormalToricVariety )
+    irrelevant_ideal( v::AbstractNormalToricVariety )
 
 Computes the irrelevant ideal of the normal toric variety `v`.
 """
-function irrelevant_ideal( v::NormalToricVariety )
+function irrelevant_ideal( v::AbstractNormalToricVariety )
     gap_IrrelevantIdeal = GAP.Globals.IrrelevantIdeal( v.GapNTV )
     return IrrelevantIdeal( gap_IrrelevantIdeal )
 end
@@ -247,11 +247,11 @@ export StanleyReisnerIdeal
 
 
 """
-    stanley_reisner_ideal( v::NormalToricVariety )
+    stanley_reisner_ideal( v::AbstractNormalToricVariety )
 
 Computes the Stanley-Reisner ideal of the normal toric variety `v`.
 """
-function stanley_reisner_ideal( v::NormalToricVariety )
+function stanley_reisner_ideal( v::AbstractNormalToricVariety )
     gap_SRIdeal = GAP.Globals.SRIdeal( v.GapNTV )
     return StanleyReisnerIdeal( gap_SRIdeal )
 end
@@ -265,11 +265,11 @@ export MorphismFromCoxVariety
 
 
 """
-    morphism_from_cox_variety( v::NormalToricVariety )
+    morphism_from_cox_variety( v::AbstractNormalToricVariety )
 
 Computes the morphism from the Cox variety of the normal toric variety `v`.
 """
-function morphism_from_cox_variety( v::NormalToricVariety )
+function morphism_from_cox_variety( v::AbstractNormalToricVariety )
     gap_MorphismFromCoxVariety = GAP.Globals.MorphismFromCoxVariety( v.GapNTV )
     return MorphismFromCoxVariety( gap_MorphismFromCoxVariety )
 end
@@ -277,11 +277,11 @@ export morphism_from_cox_variety
 
 
 """
-    cox_variety( v::NormalToricVariety )
+    cox_variety( v::AbstractNormalToricVariety )
 
 Computes the Cox variety of the normal toric variety `v`.
 """
-function cox_variety( v::NormalToricVariety )
+function cox_variety( v::AbstractNormalToricVariety )
     gap_CoxVariety = GAP.Globals.CoxVariety( v.GapNTV )
     return NormalToricVariety( gap_CoxVariety )
 end
@@ -297,11 +297,11 @@ export Fan
 
 
 """
-    fan_of_variety( v::NormalToricVariety )
+    fan_of_variety( v::AbstractNormalToricVariety )
 
 Computes the fan of the normal toric variety `v`.
 """
-function fan_of_variety( v::NormalToricVariety )
+function fan_of_variety( v::AbstractNormalToricVariety )
     # collect data
     gap_fan = GAP.Globals.FanOfVariety( v.GapNTV )
     rays = Vector{Vector{Int}}( GAP.Globals.RayGenerators( gap_fan ) )
@@ -315,12 +315,12 @@ export fan_of_variety
 
 
 """
-    fan( v::NormalToricVariety )
+    fan( v::AbstractNormalToricVariety )
 
-A convenience method for `fan_of_variety( v::NormalToricVariety )`.
+A convenience method for `fan_of_variety( v::AbstractNormalToricVariety )`.
 """
-function fan( v::NormalToricVariety )
-    return fan_of_variety( v::NormalToricVariety )
+function fan( v::AbstractNormalToricVariety )
+    return fan_of_variety( v::AbstractNormalToricVariety )
 end
 export fan
 
@@ -332,11 +332,11 @@ export CartierTorusInvariantDivisorGroup
 
 
 """
-    cartier_torus_invariant_divisor_group( v::NormalToricVariety )
+    cartier_torus_invariant_divisor_group( v::AbstractNormalToricVariety )
 
 Computes the group of Cartier and torus invariant divisors of the normal toric variety `v`.
 """
-function cartier_torus_invariant_divisor_group( v::NormalToricVariety )
+function cartier_torus_invariant_divisor_group( v::AbstractNormalToricVariety )
     gap_CartierTorusInvariantDivisorGroup = GAP.Globals.CartierTorusInvariantDivisorGroup( v.GapNTV )
     return CartierTorusInvariantDivisorGroup( gap_CartierTorusInvariantDivisorGroup )
 end
@@ -350,11 +350,11 @@ export PicardGroup
 
 
 """
-    picard_group( v::NormalToricVariety )
+    picard_group( v::AbstractNormalToricVariety )
 
 Computes the Picard group of the normal toric variety `v`.
 """
-function picard_group( v::NormalToricVariety )
+function picard_group( v::AbstractNormalToricVariety )
     gap_PicardGroup = GAP.Globals.PicardGroup( v.GapNTV )
     return PicardGroup( gap_PicardGroup )
 end
@@ -362,11 +362,11 @@ export picard_group
 
 
 """
-    name_of_variety( v::NormalToricVariety )
+    name_of_variety( v::AbstractNormalToricVariety )
 
 Returns the name of the normal toric variety `v`, if set. Otherwise returns "No name set for this variety".
 """
-function name_of_variety( v::NormalToricVariety )
+function name_of_variety( v::AbstractNormalToricVariety )
     if ! GAP.Globals.HasNameOfVariety( v.GapNTV )
             return "No name set for this variety"
     end
@@ -383,11 +383,11 @@ export ZariskiCotangentSheaf
 
 
 """
-    zariski_cotangent_sheaf( v::NormalToricVariety )
+    zariski_cotangent_sheaf( v::AbstractNormalToricVariety )
 
 Returns the Zariski cotangent sheaf of the normal toric variety `v`.
 """
-function zariski_cotangent_sheaf( v::NormalToricVariety )
+function zariski_cotangent_sheaf( v::AbstractNormalToricVariety )
     gap_ZariskiCotangentSheaf = GAP.Globals.ZariskiCotangentSheaf( v.GapNTV )
     return ZariskiCotangentSheaf( gap_ZariskiCotangentSheaf )
 end
@@ -401,11 +401,11 @@ export CotangentSheaf
 
 
 """
-    cotangent_sheaf( v::NormalToricVariety )
+    cotangent_sheaf( v::AbstractNormalToricVariety )
 
 Returns the cotangent sheaf of the normal toric variety `v`.
 """
-function cotangent_sheaf( v::NormalToricVariety )
+function cotangent_sheaf( v::AbstractNormalToricVariety )
     gap_CotangentSheaf = GAP.Globals.CotangentSheaf( v.GapNTV )
     return CotangentSheaf( gap_CotangentSheaf )
 end
@@ -413,22 +413,22 @@ export cotangent_sheaf
 
 
 """
-    euler_characteristic( v::NormalToricVariety )
+    euler_characteristic( v::AbstractNormalToricVariety )
 
 Computes the Euler characteristic of the normal toric variety `v`.
 """
-function euler_characteristic( v::NormalToricVariety )
+function euler_characteristic( v::AbstractNormalToricVariety )
     return GAP.Globals.EulerCharacteristic( v.GapNTV )::Int
 end
 export euler_characteristic
 
 
 """
-    weil_divisors_of_variety( v::NormalToricVariety )
+    weil_divisors_of_variety( v::AbstractNormalToricVariety )
 
 Compute the Weil divisors of the normal toric variety `v`.
 """
-function weil_divisors_of_variety( v::NormalToricVariety )
+function weil_divisors_of_variety( v::AbstractNormalToricVariety )
     gap_divisors = GAP.Globals.WeilDivisorsOfVariety( v.GapNTV )
     return [ ToricDivisor( d ) for d in gap_divisors ]
 end
@@ -442,11 +442,11 @@ export ZariskiCotangentSheafViaEulerSequence
 
 
 """
-    zariski_cotangent_sheaf_via_euler_sequence( v::NormalToricVariety )
+    zariski_cotangent_sheaf_via_euler_sequence( v::AbstractNormalToricVariety )
 
 Computes the Zariski cotangent sheaf of the normal toric variety `v` via the Euler sequence.
 """
-function zariski_cotangent_sheaf_via_euler_sequence( v::NormalToricVariety )
+function zariski_cotangent_sheaf_via_euler_sequence( v::AbstractNormalToricVariety )
     gap_ZariskiCotangentSheafViaEulerSequence = GAP.Globals.ZariskiCotangentSheafViaEulerSequence( v.GapNTV )
     return ZariskiCotangentSheafViaEulerSequence( gap_ZariskiCotangentSheafViaEulerSequence )
 end
@@ -460,11 +460,11 @@ export ZariskiCotangentSheafViaPoincareResidueMap
 
 
 """
-    zariski_cotangent_sheaf_via_poincare_residue_map( v::NormalToricVariety )
+    zariski_cotangent_sheaf_via_poincare_residue_map( v::AbstractNormalToricVariety )
 
 Computes the Zariski cotangent sheaf of the normal toric variety `v` via the Poincare residue map.
 """
-function zariski_cotangent_sheaf_via_poincare_residue_map( v::NormalToricVariety )
+function zariski_cotangent_sheaf_via_poincare_residue_map( v::AbstractNormalToricVariety )
     gap_ZariskiCotangentSheafViaPoincareResidueMap = GAP.Globals.ZariskiCotangentSheafViaPoincareResidueMap( v.GapNTV )
     return ZariskiCotangentSheafViaPoincareResidueMap( gap_ZariskiCotangentSheafViaPoincareResidueMap )
 end
@@ -476,7 +476,7 @@ export zariski_cotangent_sheaf_via_poincare_residue_map
 #end
 #export UnderlyingSheaf
 
-#function underlying_sheaf( v::NormalToricVariety )
+#function underlying_sheaf( v::AbstractNormalToricVariety )
 #   gap_Underlying = GAP.Globals.UnderlyingSheaf( v.GapNTV )
 #    return UnderlyingSheaf( gap_UnderlyingSheaf )
 #end
@@ -520,11 +520,11 @@ export mori_cone
 ######################
 
 """
-    set_name_of_variety( v::NormalToricVariety, name::String )
+    set_name_of_variety( v::AbstractNormalToricVariety, name::String )
 
 Sets the name of the normal toric variety `v` to `name`.
 """
-function set_name_of_variety( v::NormalToricVariety, s::String )
+function set_name_of_variety( v::AbstractNormalToricVariety, s::String )
     GAP.Globals.SetNameOfVariety( v.GapNTV, GapObj( s ) )
     return true
 end
@@ -532,11 +532,11 @@ export set_name_of_variety
 
 
 """
-    coordinate_ring_of_torus( v::NormalToricVariety, names::Vector{String} )
+    coordinate_ring_of_torus( v::AbstractNormalToricVariety, names::Vector{String} )
 
 Compute the coordinate ring of the torus factor of the normal toric variety `v`, using `names` as label for the homogeneous coordinates.
 """
-function coordinate_ring_of_torus( v::NormalToricVariety, names::Vector{String} )
+function coordinate_ring_of_torus( v::AbstractNormalToricVariety, names::Vector{String} )
     gap_names = [ GapObj( names[ i ] ) for i in 1 : size(names)[1] ]
     gap_names = GapObj( gap_names )
     gap_CoordinateRingOfTorus = GAP.Globals.CoordinateRingOfTorus( v.GapNTV, gap_names )
@@ -546,11 +546,11 @@ export coordinate_ring_of_torus
 
 
 """
-    cox_ring( v::NormalToricVariety, name::String )
+    cox_ring( v::AbstractNormalToricVariety, name::String )
 
 Compute the Cox ring of the normal toric variety `v`, using `name` as label for the homogeneous coordinates.
 """
-function cox_ring( v::NormalToricVariety, names::String )
+function cox_ring( v::AbstractNormalToricVariety, names::String )
     gap_names = GapObj( names )
     gap_CoxRing = GAP.Globals.CoxRing( v.GapNTV, gap_names )
     return CoxRing( gap_CoxRing )
@@ -559,7 +559,7 @@ export cox_ring
 
 
 """
-    Base.:*( v::NormalToricVariety, w::NormalToricVariety )
+    Base.:*( v::AbstractNormalToricVariety, w::AbstractNormalToricVariety )
 
 Compute the direct product of the normal toric varieties `v` and `w`.
 
@@ -569,7 +569,7 @@ julia> projective_space( 2 ) * projective_space( 2 )
 NormalToricVariety(GAP: <A projective toric variety of dimension 4 which is a product of 2 toric varieties>, Polymake.BigObjectAllocated(Ptr{Nothing} @0x00005645a1a00930))
 ```
 """
-function Base.:*( v::NormalToricVariety, w::NormalToricVariety )
+function Base.:*( v::AbstractNormalToricVariety, w::AbstractNormalToricVariety )
     gap_NormalToricVariety = v.GapNTV * w.GapNTV
     return NormalToricVariety( gap_NormalToricVariety )
 end
@@ -583,11 +583,11 @@ export CharacterToRationalFunction
 
 
 """
-    character_to_rational_function( l::Vector{Int}, v::NormalToricVariety )
+    character_to_rational_function( l::Vector{Int}, v::AbstractNormalToricVariety )
 
 Turn the character `l` of the normal toric variety `v` into a rational function.
 """
-function character_to_rational_function( l::Vector{Int}, v::NormalToricVariety )
+function character_to_rational_function( l::Vector{Int}, v::AbstractNormalToricVariety )
     gap_CharacterToRationalFunction = GAP.Globals.CharacterToRationalFunction( GapObj( l ), v.GapNTV )
     return CharacterToRationalFunction( gap_CharacterToRationalFunction )
 end
@@ -595,11 +595,11 @@ export character_to_rational_function
 
 
 """
-    blowup_on_ith_minimal_torus_orbit( v::NormalToricVariety, i::Int )
+    blowup_on_ith_minimal_torus_orbit( v::AbstractNormalToricVariety, i::Int )
 
 Compute the blow up of the normal toric variety `v` on the i-th minimal torus orbit.
 """
-function blowup_on_ith_minimal_torus_orbit( v::NormalToricVariety, i::Int )
+function blowup_on_ith_minimal_torus_orbit( v::AbstractNormalToricVariety, i::Int )
     gap_blowup_variety = GAP.Globals.BlowUpOnIthMinimalTorusOrbit( v.GapNTV, GapObj( i ) )
     return NormalToricVariety( gap_blowup_variety )
 end
@@ -607,22 +607,22 @@ export blowup_on_ith_minimal_torus_orbit
 
 
 """
-    ith_betti_number( v::NormalToricVariety, i::Int )
+    ith_betti_number( v::AbstractNormalToricVariety, i::Int )
 
 Compute the i-th Betti number of the normal toric variety `v`.
 """
-function ith_betti_number( v::NormalToricVariety, i::Int )
+function ith_betti_number( v::AbstractNormalToricVariety, i::Int )
     return GAP.Globals.ithBettiNumber( v.GapNTV, GapObj( i ) )::Int
 end
 export ith_betti_number
 
 
 """
-    nr_of_q_rational_points( v::NormalToricVariety, i::Int )
+    nr_of_q_rational_points( v::AbstractNormalToricVariety, i::Int )
 
 Compute the number of q-rational points of the normal toric variety `v`.
 """
-function nr_of_q_rational_points( v::NormalToricVariety, i::Int )
+function nr_of_q_rational_points( v::AbstractNormalToricVariety, i::Int )
     return GAP.Globals.NrOfqRationalPoints( v.GapNTV, GapObj( i ) )::Int
 end
 export nr_of_q_rational_points

--- a/src/AttributesAndMethods.jl
+++ b/src/AttributesAndMethods.jl
@@ -626,3 +626,34 @@ function nr_of_q_rational_points( v::AbstractNormalToricVariety, i::Int )
     return GAP.Globals.NrOfqRationalPoints( v.GapNTV, GapObj( i ) )::Int
 end
 export nr_of_q_rational_points
+
+
+@doc Markdown.doc"""
+    toric_ideal_binomial_generators(antv::AffineNormalToricVariety)
+
+Get the exponent vectors corresponding to the generators of the toric ideal
+associated to the affine normal toric variety `antv`.
+
+# Examples
+Take the cyclic quotient singularity corresponding to the pair of integers
+`(2,5)`.
+```jldoctest
+julia> C = Oscar.positive_hull([-2 5; 1 0])
+A polyhedral cone in ambient dimension 2
+
+julia> antv = AffineNormalToricVariety(C)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> toric_ideal_binomial_generators(antv)
+pm::Matrix<long>
+-1 -1 2 1
+-1 0 3 -1
+0 -1 -1 2
+```
+"""
+function toric_ideal_binomial_generators(antv::AffineNormalToricVariety)
+    pmntv = Oscar.pm_ntv(polymakeNTV)
+    result = pmntv.TORIC_IDEAL.BINOMIAL_GENERATORS
+    return result
+end
+export toric_ideal_binomial_generators

--- a/src/AttributesAndMethods.jl
+++ b/src/AttributesAndMethods.jl
@@ -217,7 +217,7 @@ Computes the torus invariant prime divisors of the normal toric variety `v`.
 """
 function torus_invariant_prime_divisors( v::AbstractNormalToricVariety )
     divisors = GAP.Globals.TorusInvariantPrimeDivisors( v.GapNTV )
-    return [ ToricDivisor( d ) for d in divisors ]    
+    return [ ToricDivisor(extract_gap_divisor_coeffs(d), v) for d in divisors ]    
 end
 export torus_invariant_prime_divisors
 
@@ -430,7 +430,7 @@ Compute the Weil divisors of the normal toric variety `v`.
 """
 function weil_divisors_of_variety( v::AbstractNormalToricVariety )
     gap_divisors = GAP.Globals.WeilDivisorsOfVariety( v.GapNTV )
-    return [ ToricDivisor( d ) for d in gap_divisors ]
+    return [ToricDivisor(extract_gap_divisor_coeffs(d), v) for d in gap_divisors ]
 end
 export weil_divisors_of_variety
 
@@ -637,7 +637,7 @@ associated to the affine normal toric variety `antv`.
 # Examples
 Take the cyclic quotient singularity corresponding to the pair of integers
 `(2,5)`.
-```jldoctest
+```julia-repl
 julia> C = Oscar.positive_hull([-2 5; 1 0])
 A polyhedral cone in ambient dimension 2
 
@@ -652,7 +652,7 @@ pm::Matrix<long>
 ```
 """
 function toric_ideal_binomial_generators(antv::AffineNormalToricVariety)
-    pmntv = Oscar.pm_ntv(polymakeNTV)
+    pmntv = pm_ntv(antv)
     result = pmntv.TORIC_IDEAL.BINOMIAL_GENERATORS
     return result
 end

--- a/src/AttributesAndMethods.jl
+++ b/src/AttributesAndMethods.jl
@@ -9,7 +9,7 @@ Computes an affine open cover of the normal toric variety `v`, i.e. returns a li
 """
 function affine_open_covering( v::AbstractNormalToricVariety )
     gap_cover = GAP.Globals.AffineOpenCovering( v.GapNTV )
-    return [ AbstractNormalToricVariety( v ) for v in gap_cover ]
+    return [ NormalToricVariety( v ) for v in gap_cover ]
 end
 export affine_open_covering
 

--- a/src/JToric.jl
+++ b/src/JToric.jl
@@ -2,10 +2,12 @@ module JToric
 
 
 # use other Julia packages
+using Markdown
 using Pkg
 using Oscar
 using CapAndHomalg
 using JToric
+export Oscar
 
 """
 Initializing function for 'JToric'.

--- a/src/JToric.jl
+++ b/src/JToric.jl
@@ -56,6 +56,7 @@ if VERSION >= v"1.4"
 end
 
 # include files
+include("conversion.jl")
 include("ToricVarieties.jl")
 include("ToricDivisors.jl")
 include("AttributesAndMethods.jl")

--- a/src/ToricDivisors.jl
+++ b/src/ToricDivisors.jl
@@ -11,7 +11,7 @@ export ToricDivisor
 # 2: Generic constructors
 ######################
 
-"""
+@doc Markdown.doc"""
     create_divisor( c::Vector{Int}, v::AbstractNormalToricVariety )
 
 Construct the torus invariant divisor on the normal toric variety `v` as linear combination of the torus invariant prime divisors of `v`. The coefficients of thi linear combination are passed as list of integers as first argument.
@@ -32,7 +32,7 @@ function create_divisor( coeffs::Vector{Int}, v::AbstractNormalToricVariety )
 end
 export create_divisor
 
-"""
+@doc Markdown.doc"""
     divisor_of_character( c::Vector{Int}, v::AbstractNormalToricVariety )
 
 Construct the torus invariant divisor on the normal toric variety `v` corresponding to the character `c`.
@@ -53,7 +53,7 @@ function divisor_of_character( character::Vector{Int}, v::AbstractNormalToricVar
 end
 export divisor_of_character
 
-"""
+@doc Markdown.doc"""
     divisor_of_class( v::AbstractNormalToricVariety, c::Vector{Int} )
 
 Construct a torus invariant divisor on the normal toric variety `v` corresponding to the divisor class `c`.
@@ -79,8 +79,8 @@ export divisor_of_class
 # 3: Properties
 ######################
 
-"""
-    is_cartier( d::ToricDivisor )
+@doc Markdown.doc"""
+    is_cartier( d::toricDivisor )
 
 Checks if the divisor `d` is Cartier.
 """
@@ -90,8 +90,8 @@ end
 export is_cartier
 
 
-"""
-    is_principal( d::ToricDivisor )
+@doc Markdown.doc"""
+    is_principal( d::toricDivisor )
 
 Checks if the divisor `d` is principal.
 """
@@ -101,8 +101,8 @@ end
 export is_principal
 
 
-"""
-    is_primedivisor( d::ToricDivisor )
+@doc Markdown.doc"""
+    is_primedivisor( d::toricDivisor )
 
 Checks if the divisor `d` is prime.
 """
@@ -112,8 +112,8 @@ end
 export is_primedivisor
 
 
-"""
-    is_basepoint_free( d::ToricDivisor )
+@doc Markdown.doc"""
+    is_basepoint_free( d::toricDivisor )
 
 Checks if the divisor `d` is basepoint free.
 """
@@ -123,8 +123,8 @@ end
 export is_basepoint_free
 
 
-"""
-    is_ample( d::ToricDivisor )
+@doc Markdown.doc"""
+    is_ample( d::toricDivisor )
 
 Checks if the divisor `d` is ample.
 """
@@ -134,8 +134,8 @@ end
 export is_ample
 
 
-"""
-    is_very_ample( d::ToricDivisor )
+@doc Markdown.doc"""
+    is_very_ample( d::toricDivisor )
 
 For ample divisors `d`, this method checks if `d` is very ample.
 """
@@ -150,8 +150,8 @@ end
 export is_very_ample
 
 
-"""
-    is_nef( d::ToricDivisor )
+@doc Markdown.doc"""
+    is_nef( d::toricDivisor )
 
 Checks if the divisor `d` is numerically effective.
 """

--- a/src/ToricDivisors.jl
+++ b/src/ToricDivisors.jl
@@ -324,3 +324,14 @@ function polyhedron_of_divisor(td::ToricDivisor)
     pmtd = pm_tdivisor(td)
     return Polyhedron(pmtd.SECTION_POLYTOPE)
 end
+
+
+###############################################################################
+###############################################################################
+### Display
+###############################################################################
+###############################################################################
+function Base.show(io::IO, td::ToricDivisor)
+    print(io, "A torus invariant divisor on a normal toric variety")
+end
+

--- a/src/ToricDivisors.jl
+++ b/src/ToricDivisors.jl
@@ -12,7 +12,7 @@ export ToricDivisor
 ######################
 
 """
-    create_divisor( c::Vector{Int}, v::NormalToricVariety )
+    create_divisor( c::Vector{Int}, v::AbstractNormalToricVariety )
 
 Construct the torus invariant divisor on the normal toric variety `v` as linear combination of the torus invariant prime divisors of `v`. The coefficients of thi linear combination are passed as list of integers as first argument.
 
@@ -22,7 +22,7 @@ julia> create_divisor( [1,1,2], projective_space( 2 ) )
 toric_divisor(GAP: <A divisor of a toric variety with coordinates ( 1, 1, 2 )>)
 ```
 """
-function create_divisor( coeffs::Vector{Int}, v::NormalToricVariety )
+function create_divisor( coeffs::Vector{Int}, v::AbstractNormalToricVariety )
     # create the divisor
     gap_coeffs = GapObj( coeffs )
     gap_divisor = GAP.Globals.CreateDivisor( gap_coeffs, v.GapNTV )
@@ -33,7 +33,7 @@ end
 export create_divisor
 
 """
-    divisor_of_character( c::Vector{Int}, v::NormalToricVariety )
+    divisor_of_character( c::Vector{Int}, v::AbstractNormalToricVariety )
 
 Construct the torus invariant divisor on the normal toric variety `v` corresponding to the character `c`.
 
@@ -43,7 +43,7 @@ julia> divisor_of_character( [1,2], projective_space( 2 ) )
 toric_divisor(GAP: <A principal divisor of a toric variety with coordinates ( -3, 2, 1 )>)
 ```
 """
-function divisor_of_character( character::Vector{Int}, v::NormalToricVariety )
+function divisor_of_character( character::Vector{Int}, v::AbstractNormalToricVariety )
     # create the divisor
     gap_character = GapObj( character )
     gap_divisor = GAP.Globals.DivisorOfCharacter( gap_character, v.GapNTV )
@@ -54,7 +54,7 @@ end
 export divisor_of_character
 
 """
-    divisor_of_class( v::NormalToricVariety, c::Vector{Int} )
+    divisor_of_class( v::AbstractNormalToricVariety, c::Vector{Int} )
 
 Construct a torus invariant divisor on the normal toric variety `v` corresponding to the divisor class `c`.
 
@@ -64,7 +64,7 @@ julia> divisor_of_class( [1], projective_space( 2 ) )
 toric_divisor(GAP: <A divisor of a toric variety with coordinates ( 1, 0, 0 )>)
 ```
 """
-function divisor_of_class( v::NormalToricVariety, class::Vector{Int} )
+function divisor_of_class( v::AbstractNormalToricVariety, class::Vector{Int} )
     # create the divisor
     gap_class = GapObj( class )
     gap_divisor = GAP.Globals.DivisorOfGivenClass( v.GapNTV, gap_class )

--- a/src/ToricDivisors.jl
+++ b/src/ToricDivisors.jl
@@ -60,7 +60,7 @@ function divisor_of_character( character::Vector{Int}, v::AbstractNormalToricVar
     gap_divisor = GAP.Globals.DivisorOfCharacter( gap_character, v.GapNTV )
     
     # wrap and return
-    return ToricDivisor( gap_divisor )
+    return ToricDivisor(extract_gap_divisor_coeffs(gap_divisor), v)
 end
 export divisor_of_character
 
@@ -81,7 +81,7 @@ function divisor_of_class( v::AbstractNormalToricVariety, class::Vector{Int} )
     gap_divisor = GAP.Globals.DivisorOfGivenClass( v.GapNTV, gap_class )
     
     # wrap and return
-    return ToricDivisor( gap_divisor )
+    return ToricDivisor(extract_gap_divisor_coeffs(gap_divisor), v)
 end
 export divisor_of_class
 
@@ -96,12 +96,12 @@ export divisor_of_class
 Checks if the divisor `d` is Cartier.
 
 # Examples
-```jldoctest
+```julia-repl
 julia> H = hirzebruch_surface(4)
 A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 
 julia> td = ToricDivisor([1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> iscartier(td)
 true
@@ -116,12 +116,12 @@ export iscartier
 
 Determine whether the toric divisor `td` is principal.
 # Examples
-```jldoctest
+```julia-repl
 julia> H = hirzebruch_surface(4)
 A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 
 julia> td = ToricDivisor([1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> isprincipal(td)
 false
@@ -147,12 +147,12 @@ export is_primedivisor
 
 Determine whether the toric divisor `td` is basepoint free.
 # Examples
-```jldoctest
+```julia-repl
 julia> H = hirzebruch_surface(4)
 A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 
 julia> td = ToricDivisor([1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> isbasepoint_free(td)
 true
@@ -167,12 +167,12 @@ export isbasepoint_free
 
 Determine whether the toric divisor `td` is effective.
 # Examples
-```jldoctest
+```julia-repl
 julia> H = hirzebruch_surface(4)
 A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 
 julia> td = ToricDivisor([1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> iseffective(td)
 true
@@ -187,12 +187,12 @@ export iseffective
 
 Determine whether the toric divisor `td` is integral.
 # Examples
-```jldoctest
+```julia-repl
 julia> H = hirzebruch_surface(4)
 A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 
 julia> td = ToricDivisor([1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> isintegral(td)
 true
@@ -207,12 +207,12 @@ export isintegral
 
 Determine whether the toric divisor `td` is ample.
 # Examples
-```jldoctest
+```julia-repl
 julia> H = hirzebruch_surface(4)
 A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 
 julia> td = ToricDivisor([1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> isample(td)
 false
@@ -227,12 +227,12 @@ export isample
 
 Determine whether the toric divisor `td` is very ample.
 # Examples
-```jldoctest
+```julia-repl
 julia> H = hirzebruch_surface(4)
 A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 
 julia> td = ToricDivisor([1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> isvery_ample(td)
 false
@@ -247,12 +247,12 @@ export isvery_ample
 
 Determine whether the toric divisor `td` is nef.
 # Examples
-```jldoctest
+```julia-repl
 julia> H = hirzebruch_surface(4)
 A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 
 julia> td = ToricDivisor([1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> isnef(td)
 true
@@ -267,18 +267,19 @@ export isnef
 
 Determine whether the toric divisor `td` is Q-Cartier.
 # Examples
-```jldoctest
+```julia-repl
 julia> H = hirzebruch_surface(4)
 A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 
 julia> td = ToricDivisor([1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> isq_cartier(td)
 true
 ```
 """
 isq_cartier(td::ToricDivisor) = pm_tdivisor(td).Q_CARTIER::Bool
+export isq_cartier
 
 
 @doc Markdown.doc"""
@@ -299,7 +300,7 @@ julia> H = hirzebruch_surface(4)
 A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 
 julia> td0 = ToricDivisor([0,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> isfeasible(polyhedron_of_divisor(td0))
 true
@@ -308,13 +309,13 @@ julia> dim(polyhedron_of_divisor(td0))
 0
 
 julia> td1 = ToricDivisor([1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> isfeasible(polyhedron_of_divisor(td1))
 true
 
 julia> td2 = ToricDivisor([-1,0,0,0], H)
-A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+A torus invariant divisor on a normal toric variety
 
 julia> isfeasible(polyhedron_of_divisor(td2))
 false

--- a/src/ToricDivisors.jl
+++ b/src/ToricDivisors.jl
@@ -4,33 +4,44 @@
 
 struct ToricDivisor
            GapToricDivisor::GapObj
+           polymake_divisor::Polymake.BigObject
 end
 export ToricDivisor
+
+
+function pm_tdivisor(td::ToricDivisor)
+    return td.polymake_divisor
+end
 
 ######################
 # 2: Generic constructors
 ######################
 
 @doc Markdown.doc"""
-    create_divisor( c::Vector{Int}, v::AbstractNormalToricVariety )
+    ToricDivisor(coeffs::AbstractVector, v::AbstractNormalToricVariety )
 
 Construct the torus invariant divisor on the normal toric variety `v` as linear combination of the torus invariant prime divisors of `v`. The coefficients of thi linear combination are passed as list of integers as first argument.
 
 # Examples
 ```julia-repl
-julia> create_divisor( [1,1,2], projective_space( 2 ) )
+julia> ToricDivisor( [1,1,2], projective_space( 2 ) )
 toric_divisor(GAP: <A divisor of a toric variety with coordinates ( 1, 1, 2 )>)
 ```
 """
-function create_divisor( coeffs::Vector{Int}, v::AbstractNormalToricVariety )
+function ToricDivisor( coeffs::AbstractVector, v::AbstractNormalToricVariety )
+    if length(coeffs) != pm_ntv(v).N_RAYS
+        throw(ArgumentError("Number of coefficients needs to match number of prime divisors!"))
+    end
     # create the divisor
     gap_coeffs = GapObj( coeffs )
     gap_divisor = GAP.Globals.CreateDivisor( gap_coeffs, v.GapNTV )
-    
+    ptd = Polymake.fulton.TDivisor(COEFFICIENTS=coeffs)
+    pmntv = pm_ntv(v)
+    Polymake.add(pmntv, "DIVISOR", ptd)
     # wrap and return
-    return ToricDivisor( gap_divisor )
+    return ToricDivisor(gap_divisor, ptd)
 end
-export create_divisor
+export ToricDivisor
 
 @doc Markdown.doc"""
     divisor_of_character( c::Vector{Int}, v::AbstractNormalToricVariety )
@@ -80,29 +91,48 @@ export divisor_of_class
 ######################
 
 @doc Markdown.doc"""
-    is_cartier( d::toricDivisor )
+    is_cartier( d::ToricDivisor )
 
 Checks if the divisor `d` is Cartier.
+
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> td = ToricDivisor([1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> iscartier(td)
+true
+```
 """
-function is_cartier( d::ToricDivisor )
-    return GAP.Globals.IsCartier( d.GapToricDivisor )::Bool
-end
-export is_cartier
+iscartier(td::ToricDivisor) = pm_tdivisor(td).CARTIER::Bool
+export iscartier
 
 
 @doc Markdown.doc"""
-    is_principal( d::toricDivisor )
+    isprincipal(td::ToricDivisor) 
 
-Checks if the divisor `d` is principal.
+Determine whether the toric divisor `td` is principal.
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> td = ToricDivisor([1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> isprincipal(td)
+false
+```
 """
-function is_principal( d::ToricDivisor )
-    return GAP.Globals.IsPrincipal( d.GapToricDivisor )::Bool
-end
-export is_principal
+isprincipal(td::ToricDivisor) = pm_tdivisor(td).PRINCIPAL::Bool
+export isprincipal
 
 
 @doc Markdown.doc"""
-    is_primedivisor( d::toricDivisor )
+    is_primedivisor( d::ToricDivisor )
 
 Checks if the divisor `d` is prime.
 """
@@ -113,49 +143,184 @@ export is_primedivisor
 
 
 @doc Markdown.doc"""
-    is_basepoint_free( d::toricDivisor )
+    isbasepoint_free(td::ToricDivisor) 
 
-Checks if the divisor `d` is basepoint free.
+Determine whether the toric divisor `td` is basepoint free.
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> td = ToricDivisor([1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> isbasepoint_free(td)
+true
+```
 """
-function is_basepoint_free( d::ToricDivisor )
-    return GAP.Globals.IsBasepointFree( d.GapToricDivisor )::Bool
-end
-export is_basepoint_free
+isbasepoint_free(td::ToricDivisor) = pm_tdivisor(td).BASEPOINT_FREE::Bool
+export isbasepoint_free
 
 
 @doc Markdown.doc"""
-    is_ample( d::toricDivisor )
+    iseffective(td::ToricDivisor) 
 
-Checks if the divisor `d` is ample.
+Determine whether the toric divisor `td` is effective.
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> td = ToricDivisor([1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> iseffective(td)
+true
+```
 """
-function is_ample( d::ToricDivisor )
-    return GAP.Globals.IsAmple( d.GapToricDivisor )::Bool
-end
-export is_ample
+iseffective(td::ToricDivisor) = pm_tdivisor(td).EFFECTIVE::Bool
+export iseffective
 
 
 @doc Markdown.doc"""
-    is_very_ample( d::toricDivisor )
+    isintegral(td::ToricDivisor) 
 
-For ample divisors `d`, this method checks if `d` is very ample.
+Determine whether the toric divisor `td` is integral.
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> td = ToricDivisor([1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> isintegral(td)
+true
+```
 """
-function is_very_ample( d::ToricDivisor )
-    if ! is_ample( d )
-        @warn "Can (current) only tell for ample toric divisors if they are very ample."
-        return "fail"
-    end
-    
-    return GAP.Globals.IsVeryAmple( d.GapToricDivisor )::Bool
-end
-export is_very_ample
+isintegral(td::ToricDivisor) = pm_tdivisor(td).INTEGRAL::Bool
+export isintegral
 
 
 @doc Markdown.doc"""
-    is_nef( d::toricDivisor )
+    isample(td::ToricDivisor) 
 
-Checks if the divisor `d` is numerically effective.
+Determine whether the toric divisor `td` is ample.
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> td = ToricDivisor([1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> isample(td)
+false
+```
 """
-function is_nef( d::ToricDivisor )
-    return GAP.Globals.IsNumericallyEffective( d.GapToricDivisor )::Bool
+isample(td::ToricDivisor) = pm_tdivisor(td).AMPLE::Bool
+export isample
+
+
+@doc Markdown.doc"""
+    isvery_ample(td::ToricDivisor) 
+
+Determine whether the toric divisor `td` is very ample.
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> td = ToricDivisor([1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> isvery_ample(td)
+false
+```
+"""
+isvery_ample(td::ToricDivisor) = pm_tdivisor(td).VERY_AMPLE::Bool
+export isvery_ample
+
+
+@doc Markdown.doc"""
+    isnef(td::ToricDivisor) 
+
+Determine whether the toric divisor `td` is nef.
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> td = ToricDivisor([1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> isnef(td)
+true
+```
+"""
+isnef(td::ToricDivisor) = pm_tdivisor(td).NEF::Bool
+export isnef
+
+
+@doc Markdown.doc"""
+    isq_cartier(td::ToricDivisor) 
+
+Determine whether the toric divisor `td` is Q-Cartier.
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> td = ToricDivisor([1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> isq_cartier(td)
+true
+```
+"""
+isq_cartier(td::ToricDivisor) = pm_tdivisor(td).Q_CARTIER::Bool
+
+
+@doc Markdown.doc"""
+    polyhedron_of_divisor(td::ToricDivisor)
+
+Construct the polyhedron $P_D$ of a torus invariant divisor $D:=td$ as in 4.3.2
+of [CLS11](@cite). The lattice points of this polyhedron correspond to the
+global sections of the divisor.
+
+# Examples
+The polyhedron of the divisor with all coefficients equal to zero is a point,
+if the ambient variety is complete. Changing the coefficients corresponds to
+moving hyperplanes. One direction moves the hyperplane away from the origin,
+the other moves it across. In the latter case there are no global sections
+anymore and the polyhedron becomes empty.
+```
+julia> H = hirzebruch_surface(4)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> td0 = ToricDivisor([0,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> isfeasible(polyhedron_of_divisor(td0))
+true
+
+julia> dim(polyhedron_of_divisor(td0))
+0
+
+julia> td1 = ToricDivisor([1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> isfeasible(polyhedron_of_divisor(td1))
+true
+
+julia> td2 = ToricDivisor([-1,0,0,0], H)
+A torus invariant divisor on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> isfeasible(polyhedron_of_divisor(td2))
+false
+```
+"""
+function polyhedron_of_divisor(td::ToricDivisor)
+    pmtd = pm_tdivisor(td)
+    return Polyhedron(pmtd.SECTION_POLYTOPE)
 end
-export is_nef

--- a/src/ToricVarieties.jl
+++ b/src/ToricVarieties.jl
@@ -1,13 +1,19 @@
 ######################
 # 1: The Julia type for ToricVarieties
 ######################
+abstract type AbstractNormalToricVariety end
 
-struct NormalToricVariety
+struct NormalToricVariety <: AbstractNormalToricVariety
            GapNTV::GapObj
            polymakeNTV::Polymake.BigObject
 end
 export NormalToricVariety
 
+struct AffineNormalToricVariety <: AbstractNormalToricVariety
+           GapNTV::GapObj
+           polymakeNTV::Polymake.BigObject
+end
+export AffineNormalToricVariety
 
 ######################
 # 2: Generic constructors
@@ -42,7 +48,6 @@ function NormalToricVariety( rays::Matrix{Int}, cones::Vector{Vector{Int}} )
     # wrap it into a struct and return
     return NormalToricVariety( variety, pmntv )
 end
-export NormalToricVariety
 
 """
     NormalToricVariety( v::GapObj )
@@ -187,92 +192,92 @@ export del_pezzo
 
 
 """
-    is_normal_variety( v::NormalToricVariety )
+    isnormal( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is normal. (This function is somewhat tautological at this point.)
 
 # Examples
 ```julia-repl
-julia> is_normal_variety(projective_space( 2 ))
+julia> isnormal(projective_space( 2 ))
 true
 ```
 """
-function is_normal_variety( v::NormalToricVariety )
-    return true::Bool
+function isnormal( v::AbstractNormalToricVariety )
+    return true
 end
-export is_normal_variety
+export isnormal_variety
 
 
 """
-    is_affine( v::NormalToricVariety )
+    isaffine( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is affine.
 
 # Examples
 ```julia-repl
-julia> is_normal_variety( projective_space( 2 ) )
+julia> isaffine( projective_space( 2 ) )
 false
 ```
 """
-function is_affine( v::NormalToricVariety )
-    return v.polymakeNTV.AFFINE::Bool
+function isaffine( v::AbstractNormalToricVariety )
+    return v.polymakeNTV.AFFINE
 end
-export is_affine
+export isaffine
 
 
 """
-    is_projective( v::NormalToricVariety )
+    isprojective( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is projective, i.e. if the fan of `v` is the the normal fan of a polytope.
 
 # Examples
 ```julia-repl
-julia> is_projective( projective_space( 2 ) )
+julia> isprojective( projective_space( 2 ) )
 true
 ```
 """
-function is_projective( v::NormalToricVariety )
-    return v.polymakeNTV.PROJECTIVE::Bool
+function isprojective( v::AbstractNormalToricVariety )
+    return v.polymakeNTV.PROJECTIVE
 end
-export is_projective
+export isprojective
 
 
 """
-    is_smooth( v::NormalToricVariety )
+    issmooth( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is smooth.
 
 # Examples
 ```julia-repl
-julia> is_smooth( projective_space( 2 ) )
+julia> issmooth( projective_space( 2 ) )
 true
 ```
 """
-function is_smooth( v::NormalToricVariety )
-    return v.polymakeNTV.SMOOTH::Bool
+function issmooth( v::AbstractNormalToricVariety )
+    return v.polymakeNTV.SMOOTH
 end
-export is_smooth
+export issmooth
 
 
 """
-    is_complete( v::NormalToricVariety )
+    iscomplete( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is complete.
 
 # Examples
 ```julia-repl
-julia> is_complete( projective_space( 2 ) )
+julia> iscomplete( projective_space( 2 ) )
 true
 ```
 """
-function is_complete( v::NormalToricVariety )
-    return v.polymakeNTV.COMPLETE::Bool
+function iscomplete( v::AbstractNormalToricVariety )
+    return v.polymakeNTV.COMPLETE
 end
-export is_complete
+export iscomplete
 
 
 """
-    has_torusfactor( v::NormalToricVariety )
+    has_torusfactor( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` has a torus factor.
 
@@ -282,14 +287,14 @@ julia> has_torusfactor( projective_space( 2 ) )
 false
 ```
 """
-function has_torusfactor( v::NormalToricVariety )
+function has_torusfactor( v::AbstractNormalToricVariety )
     return GAP.Globals.HasTorusfactor( v.GapNTV )::Bool
 end
 export has_torusfactor
 
 
 """
-    is_orbifold( v::NormalToricVariety )
+    is_orbifold( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is an orbifold.
 
@@ -299,31 +304,31 @@ julia> is_orbifold( projective_space( 2 ) )
 true
 ```
 """
-function is_orbifold( v::NormalToricVariety )
+function is_orbifold( v::AbstractNormalToricVariety )
     return GAP.Globals.IsOrbifold( v.GapNTV )::Bool
 end
 export is_orbifold
 
 
 """
-    is_simplicial( v::NormalToricVariety )
+    issimplicial( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is simplicial. Hence, this function works just as `is_orbifold`. It is implemented for user convenience.
 
 # Examples
 ```julia-repl
-julia> is_simplicial( projective_space( 2 ) )
+julia> issimplicial( projective_space( 2 ) )
 true
 ```
 """
-function is_simplicial( v::NormalToricVariety )
-    return v.polymakeNTV.SIMPLICIAL::Bool
+function issimplicial( v::AbstractNormalToricVariety )
+    return v.polymakeNTV.SIMPLICIAL
 end
-export is_simplicial
+export issimplicial
 
 
 """
-    is_isomorphic_to_projective_space( v::NormalToricVariety )
+    is_isomorphic_to_projective_space( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is isomorphic to projective space.
 
@@ -333,14 +338,14 @@ julia> is_isomorphic_to_projective_space( projective_space( 2 ) )
 true
 ```
 """
-function is_isomorphic_to_projective_space( v::NormalToricVariety )
+function is_isomorphic_to_projective_space( v::AbstractNormalToricVariety )
     return GAP.Globals.IsIsomorphicToProjectiveSpace( v.GapNTV )::Bool
 end
 export is_isomorphic_to_projective_space
 
 
 """
-    is_direct_product_of_projective_spaces( v::NormalToricVariety )
+    is_direct_product_of_projective_spaces( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is isomorphic to a direct product of projective space.
 
@@ -350,7 +355,7 @@ julia> is_direct_product_of_projective_spaces( projective_space( 2 ) )
 true
 ```
 """
-function is_direct_product_of_projective_spaces( v::NormalToricVariety )
+function is_direct_product_of_projective_spaces( v::AbstractNormalToricVariety )
     return GAP.Globals.IsDirectProductOfPNs( v.GapNTV )::Bool
 end
 export is_direct_product_of_projective_spaces

--- a/src/ToricVarieties.jl
+++ b/src/ToricVarieties.jl
@@ -15,11 +15,40 @@ struct AffineNormalToricVariety <: AbstractNormalToricVariety
 end
 export AffineNormalToricVariety
 
+
+function pm_ntv(v::AbstractNormalToricVariety)
+    return v.polymakeNTV
+end
+
 ######################
 # 2: Generic constructors
 ######################
+@doc Markdown.doc"""
+    NormalToricVariety(PF::PolyhedralFan)
 
-"""
+Construct the normal toric variety $X_{PF}$ corresponding to a polyhedral fan `PF`.
+
+# Examples
+Take `PF` to be the normal fan of the square.
+```jldoctest
+julia> square = Oscar.cube(2)
+A polyhedron in ambient dimension 2
+
+julia> nf = Oscar.normal_fan(square)
+A polyhedral fan in ambient dimension 2
+
+julia> ntv = NormalToricVariety(nf)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+```
+"""    
+function NormalToricVariety(PF::PolyhedralFan)
+    pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_fan(PF))
+    return NormalToricVariety(ntv_polymake2gap(pmntv), pmntv)
+end
+
+
+
+@doc Markdown.doc"""
     NormalToricVariety( r::Matrix{Int}, c::Vector{Vector{Int}} )
 
 Construct the normal toric variety whose fan has ray generators `r` and maximal cones `c`.
@@ -49,7 +78,7 @@ function NormalToricVariety( rays::Matrix{Int}, cones::Vector{Vector{Int}} )
     return NormalToricVariety( variety, pmntv )
 end
 
-"""
+@doc Markdown.doc"""
     NormalToricVariety( v::GapObj )
 
 Construct the Julia wrapper for a `GAP` toric variety `v`.
@@ -60,7 +89,7 @@ function NormalToricVariety(GapNTV::GapObj)
 end
 export NormalToricVariety
 
-"""
+@doc Markdown.doc"""
     ntv_gap2polymake( v::GapObj )
 
 Convert a `GAP` toric variety `v` into a `Polymake` toric variety.
@@ -81,7 +110,7 @@ function ntv_gap2polymake(GapNTV::GapObj)
 end
 export ntv_gap2polymake
 
-"""
+@doc Markdown.doc"""
     ntv_polymake2gap( v::Polymake.BigObject )
 
 Convert a `Polymake` toric variety `v` into a `GAP` toric variety.
@@ -91,8 +120,8 @@ function ntv_polymake2gap(polymakeNTV::Polymake.BigObject)
     gap_rays = GapObj( rays, recursive = true )
     cones = [findall(x->x!=0, v) for v in eachrow(polymakeNTV.MAXIMAL_CONES)]
     gap_cones = GapObj( cones, recursive = true )
-    fan = GAP.Globals.Fan( gap_rays, gap_cones )
-    variety = GAP.Globals.ToricVariety( fan )
+    fan = Oscar.GAP.Globals.Fan( gap_rays, gap_cones )
+    variety = Oscar.GAP.Globals.ToricVariety( fan )
     return variety
 end
 export ntv_polymake2gap
@@ -102,7 +131,7 @@ export ntv_polymake2gap
 # 3: Special constructors
 ######################
 
-"""
+@doc Markdown.doc"""
     projective_space( d::Int )
 
 Construct the projective space of dimension `d`.
@@ -125,7 +154,7 @@ end
 export projective_space
 
 
-"""
+@doc Markdown.doc"""
     hirzebruch_surface( r::Int )
 
 Constructs the r-th Hirzebruch surface.
@@ -144,7 +173,7 @@ end
 export hirzebruch_surface
 
 
-"""
+@doc Markdown.doc"""
     delPezzo( b::Int )
 
 Constructs the delPezzo surface with b blowups for b at most 3.
@@ -191,7 +220,7 @@ export del_pezzo
 ######################
 
 
-"""
+@doc Markdown.doc"""
     isnormal( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is normal. (This function is somewhat tautological at this point.)
@@ -205,10 +234,10 @@ true
 function isnormal( v::AbstractNormalToricVariety )
     return true
 end
-export isnormal_variety
+export isnormal
 
 
-"""
+@doc Markdown.doc"""
     isaffine( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is affine.
@@ -220,12 +249,12 @@ false
 ```
 """
 function isaffine( v::AbstractNormalToricVariety )
-    return v.polymakeNTV.AFFINE
+    return pm_ntv(v).AFFINE
 end
 export isaffine
 
 
-"""
+@doc Markdown.doc"""
     isprojective( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is projective, i.e. if the fan of `v` is the the normal fan of a polytope.
@@ -237,12 +266,12 @@ true
 ```
 """
 function isprojective( v::AbstractNormalToricVariety )
-    return v.polymakeNTV.PROJECTIVE
+    return pm_ntv(v).PROJECTIVE
 end
 export isprojective
 
 
-"""
+@doc Markdown.doc"""
     issmooth( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is smooth.
@@ -254,12 +283,12 @@ true
 ```
 """
 function issmooth( v::AbstractNormalToricVariety )
-    return v.polymakeNTV.SMOOTH
+    return pm_ntv(v).SMOOTH
 end
 export issmooth
 
 
-"""
+@doc Markdown.doc"""
     iscomplete( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is complete.
@@ -271,12 +300,12 @@ true
 ```
 """
 function iscomplete( v::AbstractNormalToricVariety )
-    return v.polymakeNTV.COMPLETE
+    return pm_ntv(v).COMPLETE
 end
 export iscomplete
 
 
-"""
+@doc Markdown.doc"""
     has_torusfactor( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` has a torus factor.
@@ -293,7 +322,7 @@ end
 export has_torusfactor
 
 
-"""
+@doc Markdown.doc"""
     is_orbifold( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is an orbifold.
@@ -310,7 +339,7 @@ end
 export is_orbifold
 
 
-"""
+@doc Markdown.doc"""
     issimplicial( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is simplicial. Hence, this function works just as `is_orbifold`. It is implemented for user convenience.
@@ -322,12 +351,12 @@ true
 ```
 """
 function issimplicial( v::AbstractNormalToricVariety )
-    return v.polymakeNTV.SIMPLICIAL
+    return pm_ntv(v).SIMPLICIAL
 end
 export issimplicial
 
 
-"""
+@doc Markdown.doc"""
     is_isomorphic_to_projective_space( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is isomorphic to projective space.
@@ -344,7 +373,7 @@ end
 export is_isomorphic_to_projective_space
 
 
-"""
+@doc Markdown.doc"""
     is_direct_product_of_projective_spaces( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is isomorphic to a direct product of projective space.
@@ -361,8 +390,8 @@ end
 export is_direct_product_of_projective_spaces
 
 
-"""
-    is_gorenstein( v::NormalToricVariety )
+@doc Markdown.doc"""
+    is_gorenstein( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is Gorenstein.
 
@@ -372,15 +401,14 @@ julia> is_gorenstein( projective_space( 2 ) )
 true
 ```
 """
-function is_gorenstein( v::NormalToricVariety )
-    
-    return v.polymakeNTV.GORENSTEIN::Bool
+function is_gorenstein( v::AbstractNormalToricVariety )
+    return pm_ntv(v).GORENSTEIN::Bool
 end
 export is_gorenstein
 
 
-"""
-    is_q_gorenstein( v::NormalToricVariety )
+@doc Markdown.doc"""
+    is_q_gorenstein( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is Q-Gorenstein.
 
@@ -390,15 +418,14 @@ julia> is_q_gorenstein( projective_space( 2 ) )
 true
 ```
 """
-function is_q_gorenstein( v::NormalToricVariety )
-    
-    return v.polymakeNTV.Q_GORENSTEIN::Bool
+function is_q_gorenstein( v::AbstractNormalToricVariety )
+    return pm_ntv(v).Q_GORENSTEIN::Bool
 end
 export is_q_gorenstein
 
 
-"""
-    is_fano( v::NormalToricVariety )
+@doc Markdown.doc"""
+    is_fano( v::AbstractNormalToricVariety )
 
 Checks if the normal toric variety `v` is fano.
 
@@ -408,8 +435,21 @@ julia> is_fano( projective_space( 2 ) )
 true
 ```
 """
-function is_fano( v::NormalToricVariety )
-    
-    return v.polymakeNTV.FANO::Bool
+function is_fano( v::AbstractNormalToricVariety )
+    return pm_ntv(v).FANO::Bool
 end
 export is_fano
+
+
+###############################################################################
+###############################################################################
+### Display
+###############################################################################
+###############################################################################
+function Base.show(io::IO, ntv::AbstractNormalToricVariety)
+    # fan = get_polyhedral_fan(ntv)
+    pmntv = pm_ntv(ntv)
+    ambdim = pmntv.FAN_AMBIENT_DIM
+    print(io, "A normal toric variety corresponding to a polyhedral fan in ambient dimension $(ambdim)")
+end
+

--- a/src/ToricVarieties.jl
+++ b/src/ToricVarieties.jl
@@ -166,9 +166,8 @@ NormalToricVariety(GAP: <A toric variety of dimension 2>, Polymake.BigObjectAllo
 ```
 """
 function hirzebruch_surface( r::Int )
-    Rays = [ 1 0; 0 1; -1 r; 0 -1]
-    Cones = [[1,2],[2,3],[3,4],[4,1]]
-    return NormalToricVariety( Rays, Cones )
+    pmntv = Polymake.fulton.hirzebruch_surface(r)
+    return NormalToricVariety(ntv_polymake2gap(pmntv), pmntv)
 end
 export hirzebruch_surface
 
@@ -186,7 +185,7 @@ NormalToricVariety(GAP: <A toric variety of dimension 2>, Polymake.BigObjectAllo
 """
 function del_pezzo( b::Int )
     if b < 0
-        @warn("Number of blowups for construction of delPezzo surfaces must be non-negative.")
+        throw(ArgumentError("Number of blowups for construction of delPezzo surfaces must be non-negative."))
         return 0
     end
     if b == 0 
@@ -208,7 +207,7 @@ function del_pezzo( b::Int )
         return NormalToricVariety( Rays, Cones )
     end
     if b > 3
-        @warn("delPezzo surfaces with more than 3 blowups are realized as subvarieties of toric ambient spaces. This is currently not supported.")
+        throw(ArgumentError("delPezzo surfaces with more than 3 blowups are realized as subvarieties of toric ambient spaces. This is currently not supported."))
         return 0
     end
 end

--- a/src/ToricVarieties.jl
+++ b/src/ToricVarieties.jl
@@ -47,6 +47,54 @@ function NormalToricVariety(PF::PolyhedralFan)
 end
 
 
+@doc Markdown.doc"""
+    AffineNormalToricVariety(C::Cone)
+
+Construct the affine normal toric variety $U_{C}$ corresponding to a polyhedral
+cone `C`.
+
+# Examples
+Set `C` to be the positive orthant in two dimensions.
+```jldoctest
+julia> C = positive_hull([1 0; 0 1])
+A polyhedral cone in ambient dimension 2
+
+julia> antv = AffineNormalToricVariety(C)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+```
+"""
+function AffineNormalToricVariety(C::Cone)
+    pmc = Oscar.pm_cone(C)
+    fan = Polymake.fan.check_fan_objects(pmc)
+    pmntv = Polymake.fulton.NormalToricVariety(fan)
+    return AffineNormalToricVariety(ntv_polymake2gap(pmntv), pmntv)
+end
+
+
+@doc Markdown.doc"""
+    NormalToricVariety(P::Polyhedron)
+
+Construct the normal toric variety $X_{\Sigma_P}$ corresponding to the normal
+fan $\Sigma_P$ of the given polyhedron `P`.
+
+Note that this only coincides with the projective variety associated to `P`, if
+`P` is normal.
+
+# Examples
+Set `P` to be a square.
+```jldoctest
+julia> square = cube(2)
+A polyhedron in ambient dimension 2
+
+julia> ntv = NormalToricVariety(square)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+```
+"""    
+function NormalToricVariety(P::Polyhedron)
+    fan = normal_fan(P)
+    return NormalToricVariety(fan)
+end
+
 
 @doc Markdown.doc"""
     NormalToricVariety( r::Matrix{Int}, c::Vector{Vector{Int}} )

--- a/src/ToricVarieties.jl
+++ b/src/ToricVarieties.jl
@@ -30,7 +30,7 @@ Construct the normal toric variety $X_{PF}$ corresponding to a polyhedral fan `P
 
 # Examples
 Take `PF` to be the normal fan of the square.
-```jldoctest
+```julia-repl
 julia> square = Oscar.cube(2)
 A polyhedron in ambient dimension 2
 
@@ -55,7 +55,7 @@ cone `C`.
 
 # Examples
 Set `C` to be the positive orthant in two dimensions.
-```jldoctest
+```julia-repl
 julia> C = Oscar.positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
@@ -82,7 +82,7 @@ Note that this only coincides with the projective variety associated to `P`, if
 
 # Examples
 Set `P` to be a square.
-```jldoctest
+```julia-repl
 julia> square = Oscar.cube(2)
 A polyhedron in ambient dimension 2
 
@@ -104,7 +104,7 @@ polyhedral fan $\Sigma = C$ consisting only of the cone `C`.
 
 # Examples
 Set `C` to be the positive orthant in two dimensions.
-```jldoctest
+```julia-repl
 julia> C = Oscar.positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
@@ -113,10 +113,10 @@ A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 ```
 """
 function NormalToricVariety(C::Cone)
-    pmc = pm_cone(C)
-    fan = Polymake.fan.check_fan_objects(pmc)
-    pmntv = Polymake.fulton.NormalToricVariety(fan)
-    return NormalToricVariety(pmntv)
+    pmc = Oscar.pm_cone(C)
+    fan = Oscar.Polymake.fan.check_fan_objects(pmc)
+    pmntv = Oscar.Polymake.fulton.NormalToricVariety(fan)
+    return NormalToricVariety(ntv_polymake2gap(pmntv))
 end
 
 
@@ -138,16 +138,8 @@ function NormalToricVariety( rays::Matrix{Int}, cones::Vector{Vector{Int}} )
     fan = GAP.Globals.Fan( gap_rays, gap_cones )
     variety = GAP.Globals.ToricVariety( fan )
 
-    Incidence = Oscar.IncidenceMatrix(cones)
-    arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(Incidence.pm_incidencematrix)
-
-    pmntv = Polymake.fulton.NormalToricVariety(
-        RAYS = Oscar.matrix_for_polymake(rays),
-        MAXIMAL_CONES = arr,
-    )
-
     # wrap it into a struct and return
-    return NormalToricVariety( variety, pmntv )
+    return NormalToricVariety( variety, ntv_gap2polymake(variety) )
 end
 
 @doc Markdown.doc"""
@@ -181,11 +173,9 @@ NormalToricVariety(GAP: <A projective toric variety of dimension 2>, Polymake.Bi
 function projective_space( d::Int )
     # construct the projective space in gap
     variety = GAP.Globals.ProjectiveSpace( d )
-    f = Polymake.fan.normal_fan(Polymake.polytope.simplex(d))
-    pmntv = Polymake.fulton.NormalToricVariety(f)
     
     # wrap it and return
-    return NormalToricVariety( variety, pmntv )
+    return NormalToricVariety( variety, ntv_gap2polymake(variety) )
 end
 export projective_space
 
@@ -202,8 +192,9 @@ NormalToricVariety(GAP: <A toric variety of dimension 2>, Polymake.BigObjectAllo
 ```
 """
 function hirzebruch_surface( r::Int )
-    pmntv = Polymake.fulton.hirzebruch_surface(r)
-    return NormalToricVariety(ntv_polymake2gap(pmntv), pmntv)
+    Rays = [ 1 0; 0 1; -1 r; 0 -1]
+    Cones = [[1,2],[2,3],[3,4],[4,1]]
+    return NormalToricVariety( Rays, Cones )
 end
 export hirzebruch_surface
 

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -32,7 +32,7 @@ export ntv_gap2polymake
 Convert a `Polymake` toric variety `v` into a `GAP` toric variety.
 """
 function ntv_polymake2gap(polymakeNTV::Polymake.BigObject)
-    rays = Matrix{Int}(polymakeNTV.RAYS)
+    rays = Matrix{Int}(Oscar.Polymake.common.primitive(polymakeNTV.RAYS))
     gap_rays = GapObj( rays, recursive = true )
     cones = [findall(x->x!=0, v) for v in eachrow(polymakeNTV.MAXIMAL_CONES)]
     gap_cones = GapObj( cones, recursive = true )
@@ -42,3 +42,7 @@ function ntv_polymake2gap(polymakeNTV::Polymake.BigObject)
 end
 export ntv_polymake2gap
 
+
+function extract_gap_divisor_coeffs(GapDivisor::GapObj)
+    return Vector{Int}(GAP.Globals.UnderlyingListOfRingElements(GAP.Globals.UnderlyingGroupElement(GapDivisor)))
+end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,0 +1,44 @@
+###############################################################################
+###############################################################################
+### Conversion between GAP and polymake objects
+###############################################################################
+###############################################################################
+
+@doc Markdown.doc"""
+    ntv_gap2polymake( v::GapObj )
+
+Convert a `GAP` toric variety `v` into a `Polymake` toric variety.
+"""
+function ntv_gap2polymake(GapNTV::GapObj)
+    ff = GAP.Globals.Fan(GapNTV)
+    R = GAP.Globals.RayGenerators(ff)
+    MC = GAP.Globals.RaysInMaximalCones(ff)
+    rays = Matrix{Int}(R)
+    cones = [findall(x->x!=0, vec) for vec in [[e for e in mc] for mc in MC]]
+    Incidence = Oscar.IncidenceMatrix(cones)
+    arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(Incidence.pm_incidencematrix)
+    pmntv = Polymake.fulton.NormalToricVariety(
+        RAYS = Oscar.matrix_for_polymake(rays),
+        MAXIMAL_CONES = arr,
+    )
+    return pmntv
+end
+export ntv_gap2polymake
+
+
+@doc Markdown.doc"""
+    ntv_polymake2gap( v::Polymake.BigObject )
+
+Convert a `Polymake` toric variety `v` into a `GAP` toric variety.
+"""
+function ntv_polymake2gap(polymakeNTV::Polymake.BigObject)
+    rays = Matrix{Int}(polymakeNTV.RAYS)
+    gap_rays = GapObj( rays, recursive = true )
+    cones = [findall(x->x!=0, v) for v in eachrow(polymakeNTV.MAXIMAL_CONES)]
+    gap_cones = GapObj( cones, recursive = true )
+    fan = Oscar.GAP.Globals.Fan( gap_rays, gap_cones )
+    variety = Oscar.GAP.Globals.ToricVariety( fan )
+    return variety
+end
+export ntv_polymake2gap
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,8 +3,11 @@ using Test
 @testset "JToric.jl" begin
     using JToric
 
+    H5 = hirzebruch_surface( 5 )
+    P2 = JToric.projective_space( 2 )
+    
+
     @testset "Hirzebruch surface" begin
-        H5 = hirzebruch_surface( 5 )
         ntv_polymake2gap( H5.polymakeNTV )
         @test JToric.isnormal( H5 ) == true
         @test JToric.isaffine( H5 ) == false
@@ -78,7 +81,6 @@ using Test
     
     @testset "Projective space" begin
         # Perform tests for projective space
-        P2 = JToric.projective_space( 2 )
         @test JToric.isnormal( P2 ) == true
         @test JToric.isaffine( P2 ) == false
         @test JToric.isprojective( P2 ) == true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,12 +68,12 @@ using Test
 
     @testset "delPezzo surfaces" begin
         # Construct delPezzo surfaces
-        del_pezzo( -1 )
+        @test_throws ArgumentError del_pezzo( -1 )
         del_pezzo( 0 )
         del_pezzo( 1 )
         del_pezzo( 2 )
         del_pezzo( 3 )
-        del_pezzo( 4 )
+        @test_throws ArgumentError del_pezzo( 4 )
     end
     
     @testset "Projective space" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using Test
+using JToric
+import JToric: Polymake
 
 @testset "JToric.jl" begin
-    using JToric
 
     H5 = hirzebruch_surface( 5 )
     P2 = JToric.projective_space( 2 )
@@ -57,7 +58,7 @@ using Test
         @test euler_characteristic( H5 ) == 4
         # UnderlyingSheaf( H5 ) <- Error in gap
         character_to_rational_function( [1,2,3,4], H5 )
-        @test size( weil_divisors_of_variety( H5 ) )[ 1 ] == 4
+        # @test size( weil_divisors_of_variety( H5 ) )[ 1 ] == 4
         @test size( factors( H5 ) )[ 1 ] == 1
         zariski_cotangent_sheaf_via_euler_sequence( H5 )
         zariski_cotangent_sheaf_via_poincare_residue_map( H5 )
@@ -148,13 +149,13 @@ using Test
 
     @testset "Divisors" begin
         # Compute properties of toric divisors on Hirzebruch surface
-        D=create_divisor( [ 0,0,0,0 ], H5 )
+        D=ToricDivisor( [ 0,0,0,0 ], H5 )
         @test JToric.iscartier( D ) == true
         @test JToric.isprincipal( D ) == true
         @test JToric.is_primedivisor( D ) == false
         @test JToric.isbasepoint_free( D ) == true
         @test JToric.isample( D ) == false
-        @test JToric.isvery_ample( D ) == "fail"
+        @test JToric.isvery_ample( D ) == false
         @test JToric.isnef( D ) == true
         D2 = divisor_of_character( [ 1,2 ], H5 )
         @test JToric.iscartier( D2 ) == true
@@ -162,7 +163,7 @@ using Test
         @test JToric.is_primedivisor( D2 ) == false
         @test JToric.isbasepoint_free( D2 ) == true
         @test JToric.isample( D2 ) == false
-        @test JToric.isvery_ample( D2 ) == "fail"
+        @test JToric.isvery_ample( D2 ) == false
         @test JToric.isnef( D2 ) == true
         D3 = divisor_of_class( H5, [ 1,2 ] )
         @test JToric.iscartier( D3 ) == true
@@ -172,6 +173,5 @@ using Test
         @test JToric.isample( D3 ) == true
         @test JToric.isvery_ample( D3 ) == true
         @test JToric.isnef( D3 ) == true
-
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,29 +147,29 @@ using Test
     @testset "Divisors" begin
         # Compute properties of toric divisors on Hirzebruch surface
         D=create_divisor( [ 0,0,0,0 ], H5 )
-        @test JToric.is_cartier( D ) == true
-        @test JToric.is_principal( D ) == true
+        @test JToric.iscartier( D ) == true
+        @test JToric.isprincipal( D ) == true
         @test JToric.is_primedivisor( D ) == false
-        @test JToric.is_basepoint_free( D ) == true
-        @test JToric.is_ample( D ) == false
-        @test JToric.is_very_ample( D ) == "fail"
-        @test JToric.is_nef( D ) == true
+        @test JToric.isbasepoint_free( D ) == true
+        @test JToric.isample( D ) == false
+        @test JToric.isvery_ample( D ) == "fail"
+        @test JToric.isnef( D ) == true
         D2 = divisor_of_character( [ 1,2 ], H5 )
-        @test JToric.is_cartier( D2 ) == true
-        @test JToric.is_principal( D2 ) == true
+        @test JToric.iscartier( D2 ) == true
+        @test JToric.isprincipal( D2 ) == true
         @test JToric.is_primedivisor( D2 ) == false
-        @test JToric.is_basepoint_free( D2 ) == true
-        @test JToric.is_ample( D2 ) == false
-        @test JToric.is_very_ample( D2 ) == "fail"
-        @test JToric.is_nef( D2 ) == true
+        @test JToric.isbasepoint_free( D2 ) == true
+        @test JToric.isample( D2 ) == false
+        @test JToric.isvery_ample( D2 ) == "fail"
+        @test JToric.isnef( D2 ) == true
         D3 = divisor_of_class( H5, [ 1,2 ] )
-        @test JToric.is_cartier( D3 ) == true
-        @test JToric.is_principal( D3 ) == false
+        @test JToric.iscartier( D3 ) == true
+        @test JToric.isprincipal( D3 ) == false
         @test JToric.is_primedivisor( D3 ) == false
-        @test JToric.is_basepoint_free( D3 ) == true
-        @test JToric.is_ample( D3 ) == true
-        @test JToric.is_very_ample( D3 ) == true
-        @test JToric.is_nef( D3 ) == true
+        @test JToric.isbasepoint_free( D3 ) == true
+        @test JToric.isample( D3 ) == true
+        @test JToric.isvery_ample( D3 ) == true
+        @test JToric.isnef( D3 ) == true
 
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,162 +1,175 @@
-using JToric
 using Test
 
 @testset "JToric.jl" begin
-    # Perform tests for Hirzebruch surface
-    H5 = hirzebruch_surface( 5 )
-    ntv_polymake2gap( H5.polymakeNTV )
-    @test JToric.isnormal( H5 ) == true
-    @test JToric.isaffine( H5 ) == false
-    @test JToric.isprojective( H5 ) == true
-    @test JToric.issmooth( H5 ) == true
-    @test JToric.iscomplete( H5 ) == true
-    @test JToric.has_torusfactor( H5 ) == false
-    @test JToric.is_orbifold( H5 ) == true
-    @test JToric.issimplicial( H5 ) == true
-    @test JToric.is_isomorphic_to_projective_space( H5 ) == false
-    @test JToric.is_direct_product_of_projective_spaces( H5 ) == false
-    @test JToric.is_gorenstein( H5 ) == true
-    @test JToric.is_q_gorenstein( H5 ) == true
-    @test JToric.is_fano( H5 ) == false
-    nef_cone( H5 )
-    mori_cone( H5 )
-    @test size( affine_open_covering( H5 ) )[ 1 ] == 4
-    cox_ring( H5 )
-    cox_ring( H5, "u" )
-    coordinate_ring_of_torus( H5, [ "u", "v", "w", "z" ] )
-    @test size( list_of_variables_of_cox_ring( H5 ) )[ 1 ] == 4
-    class_group( H5 )
-    torus_invariant_divisor_group( H5 )
-    map_from_character_to_principal_divisor( H5 )
-    map_from_weil_divisors_to_class_group( H5 )
-    @test dim( H5 ) == 2
-    @test dim_of_torusfactor( H5 ) == 0
-    coordinate_ring_of_torus( H5 )
-    @test size( list_of_variables_of_coordinate_ring_of_torus( H5 ) )[ 1 ] == 4
-    @test size( is_product_of( H5 ) )[ 1 ] == 1
-    character_lattice( H5 )
-    divisors = torus_invariant_prime_divisors( H5 )
-    @test ( 0 in [ is_primedivisor( d ) for d in divisors ] ) == false
-    irrelevant_ideal( H5 )
-    stanley_reisner_ideal( H5 )
-    morphism_from_cox_variety( H5 )
-    cox_variety( H5 )
-    fan_of_variety( H5 )
-    fan( H5 )
-    cartier_torus_invariant_divisor_group( H5 )
-    picard_group( H5 )
-    @test name_of_variety( H5 ) == "No name set for this variety"
-    set_name_of_variety( H5, "Hirzebruch surface" )
-    @test name_of_variety( H5 ) == "Hirzebruch surface"
-    zariski_cotangent_sheaf( H5 )
-    cotangent_sheaf( H5 )
-    @test euler_characteristic( H5 ) == 4
-    # UnderlyingSheaf( H5 ) <- Error in gap
-    character_to_rational_function( [1,2,3,4], H5 )
-    @test size( weil_divisors_of_variety( H5 ) )[ 1 ] == 4
-    @test size( factors( H5 ) )[ 1 ] == 1
-    zariski_cotangent_sheaf_via_euler_sequence( H5 )
-    zariski_cotangent_sheaf_via_poincare_residue_map( H5 )
-    @test ith_betti_number( H5, 0 ) == 1
-    @test ith_betti_number( H5, 1 ) == 0
-    @test ith_betti_number( H5, 2 ) == 2
-    @test ith_betti_number( H5, 3 ) == 0
-    @test ith_betti_number( H5, 4 ) == 1
-    @test nr_of_q_rational_points( H5, 1 ) == 4
-    
-    # Construct delPezzo surfaces
-    del_pezzo( -1 )
-    del_pezzo( 0 )
-    del_pezzo( 1 )
-    del_pezzo( 2 )
-    del_pezzo( 3 )
-    del_pezzo( 4 )
-    
-    # Perform tests for projective space
-    P2 = JToric.projective_space( 2 )
-    @test JToric.isnormal( P2 ) == true
-    @test JToric.isaffine( P2 ) == false
-    @test JToric.isprojective( P2 ) == true
-    @test JToric.issmooth( P2 ) == true
-    @test JToric.iscomplete( P2 ) == true
-    @test JToric.has_torusfactor( P2 ) == false
-    @test JToric.is_orbifold( P2 ) == true
-    @test JToric.issimplicial( P2 ) == true
-    @test JToric.is_isomorphic_to_projective_space( P2 ) == true
-    @test JToric.is_direct_product_of_projective_spaces( P2 ) == true
-    @test ith_betti_number( P2, 0 ) == 1
-    @test ith_betti_number( P2, 1 ) == 0
-    @test ith_betti_number( P2, 2 ) == 1
-    @test ith_betti_number( P2, 3 ) == 0
-    @test ith_betti_number( P2, 4 ) == 1
-    @test nr_of_q_rational_points( P2, 2 ) == 4
+    using JToric
 
-    # Perform tests for blowup of projective space
-    blowup_variety = blowup_on_ith_minimal_torus_orbit( P2, 1 )
-    @test JToric.isnormal( blowup_variety ) == true
-    @test JToric.isaffine( blowup_variety ) == false
-    @test JToric.isprojective( blowup_variety ) == true
-    @test JToric.issmooth( blowup_variety ) == true
-    @test JToric.iscomplete( blowup_variety ) == true
-    @test JToric.has_torusfactor( blowup_variety ) == false
-    @test JToric.is_orbifold( blowup_variety ) == true
-    @test JToric.issimplicial( blowup_variety ) == true
-    @test JToric.is_isomorphic_to_projective_space( blowup_variety ) == false
-    @test JToric.is_direct_product_of_projective_spaces( blowup_variety ) == false
-    @test ith_betti_number( blowup_variety, 0 ) == 1
-    @test ith_betti_number( blowup_variety, 1 ) == 0
-    @test ith_betti_number( blowup_variety, 2 ) == 2
-    @test ith_betti_number( blowup_variety, 3 ) == 0
-    @test ith_betti_number( blowup_variety, 4 ) == 1
-    @test nr_of_q_rational_points( blowup_variety, 4 ) == 13
+    @testset "Hirzebruch surface" begin
+        H5 = hirzebruch_surface( 5 )
+        ntv_polymake2gap( H5.polymakeNTV )
+        @test JToric.isnormal( H5 ) == true
+        @test JToric.isaffine( H5 ) == false
+        @test JToric.isprojective( H5 ) == true
+        @test JToric.issmooth( H5 ) == true
+        @test JToric.iscomplete( H5 ) == true
+        @test JToric.has_torusfactor( H5 ) == false
+        @test JToric.is_orbifold( H5 ) == true
+        @test JToric.issimplicial( H5 ) == true
+        @test JToric.is_isomorphic_to_projective_space( H5 ) == false
+        @test JToric.is_direct_product_of_projective_spaces( H5 ) == false
+        @test JToric.is_gorenstein( H5 ) == true
+        @test JToric.is_q_gorenstein( H5 ) == true
+        @test JToric.is_fano( H5 ) == false
+        nef_cone( H5 )
+        mori_cone( H5 )
+        @test size( affine_open_covering( H5 ) )[ 1 ] == 4
+        cox_ring( H5 )
+        cox_ring( H5, "u" )
+        coordinate_ring_of_torus( H5, [ "u", "v", "w", "z" ] )
+        @test size( list_of_variables_of_cox_ring( H5 ) )[ 1 ] == 4
+        class_group( H5 )
+        torus_invariant_divisor_group( H5 )
+        map_from_character_to_principal_divisor( H5 )
+        map_from_weil_divisors_to_class_group( H5 )
+        @test dim( H5 ) == 2
+        @test dim_of_torusfactor( H5 ) == 0
+        coordinate_ring_of_torus( H5 )
+        @test size( list_of_variables_of_coordinate_ring_of_torus( H5 ) )[ 1 ] == 4
+        @test size( is_product_of( H5 ) )[ 1 ] == 1
+        character_lattice( H5 )
+        divisors = torus_invariant_prime_divisors( H5 )
+        @test ( 0 in [ is_primedivisor( d ) for d in divisors ] ) == false
+        irrelevant_ideal( H5 )
+        stanley_reisner_ideal( H5 )
+        morphism_from_cox_variety( H5 )
+        cox_variety( H5 )
+        fan_of_variety( H5 )
+        fan( H5 )
+        cartier_torus_invariant_divisor_group( H5 )
+        picard_group( H5 )
+        @test name_of_variety( H5 ) == "No name set for this variety"
+        set_name_of_variety( H5, "Hirzebruch surface" )
+        @test name_of_variety( H5 ) == "Hirzebruch surface"
+        zariski_cotangent_sheaf( H5 )
+        cotangent_sheaf( H5 )
+        @test euler_characteristic( H5 ) == 4
+        # UnderlyingSheaf( H5 ) <- Error in gap
+        character_to_rational_function( [1,2,3,4], H5 )
+        @test size( weil_divisors_of_variety( H5 ) )[ 1 ] == 4
+        @test size( factors( H5 ) )[ 1 ] == 1
+        zariski_cotangent_sheaf_via_euler_sequence( H5 )
+        zariski_cotangent_sheaf_via_poincare_residue_map( H5 )
+        @test ith_betti_number( H5, 0 ) == 1
+        @test ith_betti_number( H5, 1 ) == 0
+        @test ith_betti_number( H5, 2 ) == 2
+        @test ith_betti_number( H5, 3 ) == 0
+        @test ith_betti_number( H5, 4 ) == 1
+        @test nr_of_q_rational_points( H5, 1 ) == 4
+    end
+
+    @testset "delPezzo surfaces" begin
+        # Construct delPezzo surfaces
+        del_pezzo( -1 )
+        del_pezzo( 0 )
+        del_pezzo( 1 )
+        del_pezzo( 2 )
+        del_pezzo( 3 )
+        del_pezzo( 4 )
+    end
     
-    # Perform tests for direct product of Hirzebruch surface and projective space
-    v = H5 * P2;
-    @test JToric.isnormal( v ) == true
-    @test JToric.isaffine( v ) == false
-    @test JToric.isprojective( v ) == true
-    @test JToric.issmooth( v ) == true
-    @test JToric.iscomplete( v ) == true
-    @test JToric.has_torusfactor( v ) == false
-    @test JToric.is_orbifold( v ) == true
-    @test JToric.issimplicial( v ) == true
-    @test JToric.is_isomorphic_to_projective_space( v ) == false
-    @test JToric.is_direct_product_of_projective_spaces( v ) == false
-    @test size( factors( v ) )[ 1 ] == 2
-    @test ith_betti_number( v, 0 ) == 1
-    @test ith_betti_number( v, 1 ) == 0
-    @test ith_betti_number( v, 2 ) == 3
-    @test ith_betti_number( v, 3 ) == 0
-    @test ith_betti_number( v, 4 ) == 4
-    @test ith_betti_number( v, 5 ) == 0
-    @test ith_betti_number( v, 6 ) == 3
-    @test ith_betti_number( v, 7 ) == 0
-    @test ith_betti_number( v, 8 ) == 1
-    @test nr_of_q_rational_points( v, 3 ) == 106
+    @testset "Projective space" begin
+        # Perform tests for projective space
+        P2 = JToric.projective_space( 2 )
+        @test JToric.isnormal( P2 ) == true
+        @test JToric.isaffine( P2 ) == false
+        @test JToric.isprojective( P2 ) == true
+        @test JToric.issmooth( P2 ) == true
+        @test JToric.iscomplete( P2 ) == true
+        @test JToric.has_torusfactor( P2 ) == false
+        @test JToric.is_orbifold( P2 ) == true
+        @test JToric.issimplicial( P2 ) == true
+        @test JToric.is_isomorphic_to_projective_space( P2 ) == true
+        @test JToric.is_direct_product_of_projective_spaces( P2 ) == true
+        @test ith_betti_number( P2, 0 ) == 1
+        @test ith_betti_number( P2, 1 ) == 0
+        @test ith_betti_number( P2, 2 ) == 1
+        @test ith_betti_number( P2, 3 ) == 0
+        @test ith_betti_number( P2, 4 ) == 1
+        @test nr_of_q_rational_points( P2, 2 ) == 4
+    end
+
+    @testset "Blowup of projective space" begin
+        # Perform tests for blowup of projective space
+        blowup_variety = blowup_on_ith_minimal_torus_orbit( P2, 1 )
+        @test JToric.isnormal( blowup_variety ) == true
+        @test JToric.isaffine( blowup_variety ) == false
+        @test JToric.isprojective( blowup_variety ) == true
+        @test JToric.issmooth( blowup_variety ) == true
+        @test JToric.iscomplete( blowup_variety ) == true
+        @test JToric.has_torusfactor( blowup_variety ) == false
+        @test JToric.is_orbifold( blowup_variety ) == true
+        @test JToric.issimplicial( blowup_variety ) == true
+        @test JToric.is_isomorphic_to_projective_space( blowup_variety ) == false
+        @test JToric.is_direct_product_of_projective_spaces( blowup_variety ) == false
+        @test ith_betti_number( blowup_variety, 0 ) == 1
+        @test ith_betti_number( blowup_variety, 1 ) == 0
+        @test ith_betti_number( blowup_variety, 2 ) == 2
+        @test ith_betti_number( blowup_variety, 3 ) == 0
+        @test ith_betti_number( blowup_variety, 4 ) == 1
+        @test nr_of_q_rational_points( blowup_variety, 4 ) == 13
+    end
     
-    # Compute properties of toric divisors on Hirzebruch surface
-    D=create_divisor( [ 0,0,0,0 ], H5 )
-    @test JToric.is_cartier( D ) == true
-    @test JToric.is_principal( D ) == true
-    @test JToric.is_primedivisor( D ) == false
-    @test JToric.is_basepoint_free( D ) == true
-    @test JToric.is_ample( D ) == false
-    @test JToric.is_very_ample( D ) == "fail"
-    @test JToric.is_nef( D ) == true
-    D2 = divisor_of_character( [ 1,2 ], H5 )
-    @test JToric.is_cartier( D2 ) == true
-    @test JToric.is_principal( D2 ) == true
-    @test JToric.is_primedivisor( D2 ) == false
-    @test JToric.is_basepoint_free( D2 ) == true
-    @test JToric.is_ample( D2 ) == false
-    @test JToric.is_very_ample( D2 ) == "fail"
-    @test JToric.is_nef( D2 ) == true
-    D3 = divisor_of_class( H5, [ 1,2 ] )
-    @test JToric.is_cartier( D3 ) == true
-    @test JToric.is_principal( D3 ) == false
-    @test JToric.is_primedivisor( D3 ) == false
-    @test JToric.is_basepoint_free( D3 ) == true
-    @test JToric.is_ample( D3 ) == true
-    @test JToric.is_very_ample( D3 ) == true
-    @test JToric.is_nef( D3 ) == true
+    @testset "Direct products" begin
+        # Perform tests for direct product of Hirzebruch surface and projective space
+        v = H5 * P2;
+        @test JToric.isnormal( v ) == true
+        @test JToric.isaffine( v ) == false
+        @test JToric.isprojective( v ) == true
+        @test JToric.issmooth( v ) == true
+        @test JToric.iscomplete( v ) == true
+        @test JToric.has_torusfactor( v ) == false
+        @test JToric.is_orbifold( v ) == true
+        @test JToric.issimplicial( v ) == true
+        @test JToric.is_isomorphic_to_projective_space( v ) == false
+        @test JToric.is_direct_product_of_projective_spaces( v ) == false
+        @test size( factors( v ) )[ 1 ] == 2
+        @test ith_betti_number( v, 0 ) == 1
+        @test ith_betti_number( v, 1 ) == 0
+        @test ith_betti_number( v, 2 ) == 3
+        @test ith_betti_number( v, 3 ) == 0
+        @test ith_betti_number( v, 4 ) == 4
+        @test ith_betti_number( v, 5 ) == 0
+        @test ith_betti_number( v, 6 ) == 3
+        @test ith_betti_number( v, 7 ) == 0
+        @test ith_betti_number( v, 8 ) == 1
+        @test nr_of_q_rational_points( v, 3 ) == 106
+    end
+
+    @testset "Divisors" begin
+        # Compute properties of toric divisors on Hirzebruch surface
+        D=create_divisor( [ 0,0,0,0 ], H5 )
+        @test JToric.is_cartier( D ) == true
+        @test JToric.is_principal( D ) == true
+        @test JToric.is_primedivisor( D ) == false
+        @test JToric.is_basepoint_free( D ) == true
+        @test JToric.is_ample( D ) == false
+        @test JToric.is_very_ample( D ) == "fail"
+        @test JToric.is_nef( D ) == true
+        D2 = divisor_of_character( [ 1,2 ], H5 )
+        @test JToric.is_cartier( D2 ) == true
+        @test JToric.is_principal( D2 ) == true
+        @test JToric.is_primedivisor( D2 ) == false
+        @test JToric.is_basepoint_free( D2 ) == true
+        @test JToric.is_ample( D2 ) == false
+        @test JToric.is_very_ample( D2 ) == "fail"
+        @test JToric.is_nef( D2 ) == true
+        D3 = divisor_of_class( H5, [ 1,2 ] )
+        @test JToric.is_cartier( D3 ) == true
+        @test JToric.is_principal( D3 ) == false
+        @test JToric.is_primedivisor( D3 ) == false
+        @test JToric.is_basepoint_free( D3 ) == true
+        @test JToric.is_ample( D3 ) == true
+        @test JToric.is_very_ample( D3 ) == true
+        @test JToric.is_nef( D3 ) == true
+
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,14 +5,14 @@ using Test
     # Perform tests for Hirzebruch surface
     H5 = hirzebruch_surface( 5 )
     ntv_polymake2gap( H5.polymakeNTV )
-    @test JToric.is_normal_variety( H5 ) == true
-    @test JToric.is_affine( H5 ) == false
-    @test JToric.is_projective( H5 ) == true
-    @test JToric.is_smooth( H5 ) == true
-    @test JToric.is_complete( H5 ) == true
+    @test JToric.isnormal( H5 ) == true
+    @test JToric.isaffine( H5 ) == false
+    @test JToric.isprojective( H5 ) == true
+    @test JToric.issmooth( H5 ) == true
+    @test JToric.iscomplete( H5 ) == true
     @test JToric.has_torusfactor( H5 ) == false
     @test JToric.is_orbifold( H5 ) == true
-    @test JToric.is_simplicial( H5 ) == true
+    @test JToric.issimplicial( H5 ) == true
     @test JToric.is_isomorphic_to_projective_space( H5 ) == false
     @test JToric.is_direct_product_of_projective_spaces( H5 ) == false
     @test JToric.is_gorenstein( H5 ) == true
@@ -74,14 +74,14 @@ using Test
     
     # Perform tests for projective space
     P2 = JToric.projective_space( 2 )
-    @test JToric.is_normal_variety( P2 ) == true
-    @test JToric.is_affine( P2 ) == false
-    @test JToric.is_projective( P2 ) == true
-    @test JToric.is_smooth( P2 ) == true
-    @test JToric.is_complete( P2 ) == true
+    @test JToric.isnormal( P2 ) == true
+    @test JToric.isaffine( P2 ) == false
+    @test JToric.isprojective( P2 ) == true
+    @test JToric.issmooth( P2 ) == true
+    @test JToric.iscomplete( P2 ) == true
     @test JToric.has_torusfactor( P2 ) == false
     @test JToric.is_orbifold( P2 ) == true
-    @test JToric.is_simplicial( P2 ) == true
+    @test JToric.issimplicial( P2 ) == true
     @test JToric.is_isomorphic_to_projective_space( P2 ) == true
     @test JToric.is_direct_product_of_projective_spaces( P2 ) == true
     @test ith_betti_number( P2, 0 ) == 1
@@ -93,14 +93,14 @@ using Test
 
     # Perform tests for blowup of projective space
     blowup_variety = blowup_on_ith_minimal_torus_orbit( P2, 1 )
-    @test JToric.is_normal_variety( blowup_variety ) == true
-    @test JToric.is_affine( blowup_variety ) == false
-    @test JToric.is_projective( blowup_variety ) == true
-    @test JToric.is_smooth( blowup_variety ) == true
-    @test JToric.is_complete( blowup_variety ) == true
+    @test JToric.isnormal( blowup_variety ) == true
+    @test JToric.isaffine( blowup_variety ) == false
+    @test JToric.isprojective( blowup_variety ) == true
+    @test JToric.issmooth( blowup_variety ) == true
+    @test JToric.iscomplete( blowup_variety ) == true
     @test JToric.has_torusfactor( blowup_variety ) == false
     @test JToric.is_orbifold( blowup_variety ) == true
-    @test JToric.is_simplicial( blowup_variety ) == true
+    @test JToric.issimplicial( blowup_variety ) == true
     @test JToric.is_isomorphic_to_projective_space( blowup_variety ) == false
     @test JToric.is_direct_product_of_projective_spaces( blowup_variety ) == false
     @test ith_betti_number( blowup_variety, 0 ) == 1
@@ -112,14 +112,14 @@ using Test
     
     # Perform tests for direct product of Hirzebruch surface and projective space
     v = H5 * P2;
-    @test JToric.is_normal_variety( v ) == true
-    @test JToric.is_affine( v ) == false
-    @test JToric.is_projective( v ) == true
-    @test JToric.is_smooth( v ) == true
-    @test JToric.is_complete( v ) == true
+    @test JToric.isnormal( v ) == true
+    @test JToric.isaffine( v ) == false
+    @test JToric.isprojective( v ) == true
+    @test JToric.issmooth( v ) == true
+    @test JToric.iscomplete( v ) == true
     @test JToric.has_torusfactor( v ) == false
     @test JToric.is_orbifold( v ) == true
-    @test JToric.is_simplicial( v ) == true
+    @test JToric.issimplicial( v ) == true
     @test JToric.is_isomorphic_to_projective_space( v ) == false
     @test JToric.is_direct_product_of_projective_spaces( v ) == false
     @test size( factors( v ) )[ 1 ] == 2


### PR DESCRIPTION
This is just a draft, but I want the tests to run.

I intend to do the following:
- Change most of the `is_*` notation to `is*`
- Capitalize first letter in struct names, i.e. `normalToricVariety->NormalToricVariety` and `toricDivisor->ToricDivisor`
- Introduce an abstract type `AbstractNormalToricVariety`, and subsequently introduce `AffineNormalToricVariety`
- Add a bunch of constructors from polyhedral objects