### PR TITLE
Require Julia >= 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,8 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.4'
-          - '1.5'
           - '1.6'
           - '~1.7.0-0'
           #- 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -6,17 +6,17 @@ version = "0.1.0"
 [deps]
 CapAndHomalg = "c4774649-1891-41ea-a883-87141804c57c"
 GAP = "c863536a-3901-11e9-33e7-d5cd0df7b904"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Polymake = "d720cf60-89b5-51f5-aff5-213f193123e7"
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [compat]
 CapAndHomalg = "1.1.8"
 GAP = "0.6.2"
 Oscar = "0.6"
 Polymake = "0.5.8"
-julia = "1.4"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
... just like Oscar dev versions do

While this will soon be pointless when we merge JToric into Oscar, for now we still have some CI going on, and the Julia 1.4 tests are the slowest, the 1.5 one the second slowest.